### PR TITLE
Fixed problem "WSREP: Failed to resolve tcp://<myip>:4567"

### DIFF
--- a/pxc-57/Dockerfile
+++ b/pxc-57/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		pwgen wget \
 	&& rm -rf /var/lib/apt/lists/*
 
-RUN wget https://repo.percona.com/apt/percona-release_0.1-4.jessie_all.deb
-    dpkg -i percona-release_0.1-4.jessie_all.deb
+RUN wget https://repo.percona.com/apt/percona-release_0.1-4.jessie_all.deb \
+  && dpkg -i percona-release_0.1-4.jessie_all.deb
 
 ENV PERCONA_MAJOR 5.7
 ENV PERCONA_VERSION 5.7.16-27.19-1.jessie

--- a/pxc-57/pxc-entry.sh
+++ b/pxc-57/pxc-entry.sh
@@ -111,7 +111,12 @@ echo
 echo 'Registering in the discovery service'
 echo
 
-function join { local IFS="$1"; shift; echo "$*"; }
+function join {
+  local IFS="$1"
+  shift
+  joined=$(tr "$IFS" '\n' <<< "$*" | sort -un | tr '\n' "$IFS")
+  echo "${joined%?}"
+}
 
 # Read the list of registered IP addresses
 set +e
@@ -125,7 +130,7 @@ curl http://$DISCOVERY_SERVICE/v2/keys/pxc-cluster/queue/$CLUSTER_NAME -XPOST -d
 i=$(curl http://$DISCOVERY_SERVICE/v2/keys/pxc-cluster/queue/$CLUSTER_NAME | jq -r '.node.nodes[].value')
 
 # this remove my ip from the list
-i1=${i[@]/$ipaddr}
+i1="${i[@]/$ipaddr}"
 cluster_join1=$(join , $i1)
 
 # Register the current IP in the discovery service
@@ -138,7 +143,7 @@ curl http://$DISCOVERY_SERVICE/v2/keys/pxc-cluster/$CLUSTER_NAME/$ipaddr -XPUT -
 #i=`curl http://$DISCOVERY_SERVICE/v2/keys/pxc-cluster/$CLUSTER_NAME/ | jq -r '.node.nodes[].value'`
 i=$(curl http://$DISCOVERY_SERVICE/v2/keys/pxc-cluster/$CLUSTER_NAME/?quorum=true | jq -r '.node.nodes[]?.key' | awk -F'/' '{print $(NF)}')
 # this remove my ip from the list
-i2=${i[@]/$ipaddr}
+i2="${i[@]/$ipaddr}"
 cluster_join2=$(join , $i1)
 cluster_join=$(join , $i1 $i2 )
 echo "Joining cluster $cluster_join"


### PR DESCRIPTION
There where problems with the bash script pxc-entry.sh, which caused the initial database container to fail with "WSREP: Failed to resolve tcp://<myip>:4567".
Enhanced the "join" function to support uniq.