### PR TITLE
[BLD-690] PS docker images don't have the TokuDB enabled

### DIFF
--- a/percona-server.56/Dockerfile
+++ b/percona-server.56/Dockerfile
@@ -15,7 +15,7 @@ RUN useradd -u 1001 -r -g 0 -s /sbin/nologin \
             -c "Default Application User" mysql
 
 ENV PERCONA_MAJOR 5.6
-ENV PERCONA_VERSION 5.6.35-80.0-1.jessie
+ENV PERCONA_VERSION 5.6.35-81.0-1.jessie
 
 # the "/var/lib/mysql" stuff here is because the mysql-server postinst doesn't have an explicit way to disable the mysql_install_db codepath besides having a database already "configured" (ie, stuff in /var/lib/mysql/mysql)
 # also, we set debconf keys to make APT a little quieter
@@ -45,14 +45,15 @@ RUN sed -Ei 's/^(bind-address|log)/#&/' /etc/mysql/my.cnf \
 
 VOLUME ["/var/lib/mysql", "/var/log/mysql"]
 
+RUN cat /sys/kernel/mm/transparent_hugepage/enabled > /tmp/transparent_hugepage
 RUN sed -Ei '/log-error/s/^/#/g' -i /etc/mysql/my.cnf
-
+RUN sed -i "383s:exit 1:#exit 1:" $(which ps_tokudb_admin)
+RUN sed -i "s:^  exit 1$::" $(which ps_tokudb_admin)
+RUN sed -i "s:JEMALLOC_STATUS=$?:JEMALLOC_STATUS=0:" $(which ps_tokudb_admin)
 COPY ps-entry.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
-
 
 EXPOSE 3306
 
 USER 1001
-
 CMD [""]

--- a/percona-server.56/README.md
+++ b/percona-server.56/README.md
@@ -22,7 +22,13 @@ Start a Percona Server container as follows:
 
     docker run --name container-name -e MYSQL_ROOT_PASSWORD=secret -d percona/percona-server:tag
 
+Start a Percona Server container with enabled TokuDB as follows:
+
+    docker run --name container-name -e INIT_TOKUDB=1 -e MYSQL_ROOT_PASSWORD=secret -d percona/percona-server:tag
+
 Where `container-name` is the name you want to assign to your container, `secret` is the password to be set for the root user and `tag` is the tag specifying the version you want. See the list above for relevant tags, or look at the [full list of tags](https://registry.hub.docker.com/u/percona/percona-server/tags/manage/).
+
+WARNING:  If Transparent Huge Page allocation is enabled in the system kernel TokuDB will not be available as a storage engine
 
 ## Connect to Percona Server from an Application in Another Docker Container
 

--- a/percona-server/Dockerfile
+++ b/percona-server/Dockerfile
@@ -1,12 +1,13 @@
 FROM debian:jessie
 MAINTAINER Percona Development <info@percona.com>
-
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		apt-transport-https ca-certificates \
-		pwgen \
-	&& rm -rf /var/lib/apt/lists/*
+                apt-transport-https ca-certificates \
+                pwgen \
+        && rm -rf /var/lib/apt/lists/*
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 8507EFA5
+
 RUN echo 'deb https://repo.percona.com/apt jessie main' > /etc/apt/sources.list.d/percona.list
 
 # the numeric UID is needed for OpenShift
@@ -14,37 +15,40 @@ RUN useradd -u 1001 -r -g 0 -s /sbin/nologin \
             -c "Default Application User" mysql
 
 ENV PERCONA_MAJOR 5.7
-ENV PERCONA_VERSION 5.7.17-11-1.jessie
-
+ENV PERCONA_VERSION 5.7.17-13-1.jessie
 
 # the "/var/lib/mysql" stuff here is because the mysql-server postinst doesn't have an explicit way to disable the mysql_install_db codepath besides having a database already "configured" (ie, stuff in /var/lib/mysql/mysql)
 # also, we set debconf keys to make APT a little quieter
 RUN { \
-		echo percona-server-server-$PERCONA_MAJOR percona-server-server/root_password password 'unused'; \
-		echo percona-server-server-$PERCONA_MAJOR percona-server-server/root_password_again password 'unused'; \
-	} | debconf-set-selections \
-	&& apt-get update \
-	&& apt-get install -y --force-yes \
-		percona-server-server-$PERCONA_MAJOR=$PERCONA_VERSION \
-	&& rm -rf /var/lib/apt/lists/* \
+                echo percona-server-server-$PERCONA_MAJOR percona-server-server/root_password password 'unused'; \
+                echo percona-server-server-$PERCONA_MAJOR percona-server-server/root_password_again password 'unused'; \
+        } | debconf-set-selections \
+        && apt-get update \
+        && apt-get install --force-yes -y \
+                percona-server-server-$PERCONA_MAJOR=$PERCONA_VERSION percona-server-tokudb-$PERCONA_MAJOR=$PERCONA_VERSION\
+        && rm -rf /var/lib/apt/lists/* \
         && mv /etc/mysql/percona-server.conf.d/mysqld.cnf /etc/mysql/my.cnf \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)
-	&& sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf \
+        && sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf \
 # purge and re-create /var/lib/mysql with appropriate ownership
-	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
-	&& chown -R 1001:0 /var/lib/mysql /var/run/mysqld \
+        && rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
+        && chown -R 1001:0 /var/lib/mysql /var/run/mysqld \
 # ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
-	&& chmod 777 /var/run/mysqld
+        && chmod 777 /var/run/mysqld
 
 # comment out a few problematic configuration values
 # don't reverse lookup hostnames, they are usually another container
 RUN sed -Ei 's/^(bind-address|log)/#&/' /etc/mysql/my.cnf \
-	&& echo 'skip-host-cache\nskip-name-resolve' | awk '{ print } $1 == "[mysqld]" && c == 0 { c = 1; system("cat") }' /etc/mysql/my.cnf > /tmp/my.cnf \
-	&& mv /tmp/my.cnf /etc/mysql/my.cnf
+        && echo 'skip-host-cache\nskip-name-resolve' | awk '{ print } $1 == "[mysqld]" && c == 0 { c = 1; system("cat") }' /etc/mysql/my.cnf > /tmp/my.cnf \
+        && mv /tmp/my.cnf /etc/mysql/my.cnf
 
 VOLUME ["/var/lib/mysql", "/var/log/mysql"]
 
 RUN sed -Ei '/log-error/s/^/#/g' -i /etc/mysql/my.cnf
+RUN cat /sys/kernel/mm/transparent_hugepage/enabled > /tmp/transparent_hugepage
+RUN sed -i "514s:exit 1:#exit 1:" $(which ps_tokudb_admin)
+RUN sed -i "s:^  exit 1$::" $(which ps_tokudb_admin)
+RUN sed -i "s:JEMALLOC_STATUS=$?:JEMALLOC_STATUS=0:" $(which ps_tokudb_admin)
 
 COPY ps-entry.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/percona-server/README.md
+++ b/percona-server/README.md
@@ -22,7 +22,13 @@ Start a Percona Server container as follows:
 
     docker run --name container-name -e MYSQL_ROOT_PASSWORD=secret -d percona/percona-server:tag
 
+Start a Percona Server container with enabled TokuDB as follows:
+
+    docker run --name container-name -e INIT_TOKUDB=1 -e MYSQL_ROOT_PASSWORD=secret -d percona/percona-server:tag
+
 Where `container-name` is the name you want to assign to your container, `secret` is the password to be set for the root user and `tag` is the tag specifying the version you want. See the list above for relevant tags, or look at the [full list of tags](https://registry.hub.docker.com/u/percona/percona-server/tags/manage/).
+
+WARNING:  If Transparent Huge Page allocation is enabled in the system kernel TokuDB will not be available as a storage engine
 
 ## Connect to Percona Server from an Application in Another Docker Container
 

--- a/percona-server/ps-entry.sh
+++ b/percona-server/ps-entry.sh
@@ -2,102 +2,102 @@
 set -e
 
 USER_ID=$(id -u)
-
 # if command starts with an option, prepend mysqld
 if [ "${1:0:1}" = '-' ]; then
-	CMDARG="$@"
+        CMDARG="$@"
 fi
-	# comment out log output in my.cnf
+        # comment out log output in my.cnf
+THP_ENABLED=$(cat /tmp/transparent_hugepage | grep -v '\[never\]' | wc -l )
 
-	if [ -n "$INIT_TOKUDB" ]; then
-		export LD_PRELOAD=/lib64/libjemalloc.so.1
-	fi
-	# Get config
-	DATADIR="$("mysqld" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
+        if [ -n "$INIT_TOKUDB" ] && [ $THP_ENABLED == 0 ]; then
+                export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1
+        fi
+        # Get config
+        DATADIR="$("mysqld" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 
-	if [ ! -d "$DATADIR/mysql" ]; then
-		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+        if [ ! -d "$DATADIR/mysql" ]; then
+                if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
                         echo >&2 'error: database is uninitialized and password option is not specified '
                         echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD and MYSQL_RANDOM_ROOT_PASSWORD'
                         exit 1
                 fi
-		mkdir -p "$DATADIR"
+                mkdir -p "$DATADIR"
 
-		echo "Running --initialize-insecure datadir: $DATADIR"
-		mysqld --no-defaults --initialize-insecure --datadir="$DATADIR"
-		echo 'Finished --initialize-insecure'
+                echo "Running --initialize-insecure datadir: $DATADIR"
+                mysqld --no-defaults --initialize-insecure --datadir="$DATADIR"
+                echo 'Finished --initialize-insecure'
 
-		mysqld --no-defaults --datadir="$DATADIR" --skip-networking &
-		pid="$!"
+                mysqld --no-defaults --datadir="$DATADIR" --skip-networking &
+                pid="$!"
 
-		mysql=( mysql --protocol=socket -uroot )
+                mysql=( mysql --protocol=socket -uroot )
 
-		for i in {3000..0}; do
-			if echo 'SELECT 1' | "${mysql[@]}" ; then
-				break
-			fi
-			echo 'MySQL init process in progress...'
-			sleep 1
-		done
-		if [ "$i" = 0 ]; then
-			echo >&2 'MySQL init process failed.'
-			exit 1
-		fi
+                for i in {3000..0}; do
+                        if echo 'SELECT 1' | "${mysql[@]}" ; then
+                                break
+                        fi
+                        echo 'MySQL init process in progress...'
+                        sleep 1
+                done
+                if [ "$i" = 0 ]; then
+                        echo >&2 'MySQL init process failed.'
+                        exit 1
+                fi
 
-		# sed is for https://bugs.mysql.com/bug.php?id=20545
-		mysql_tzinfo_to_sql /usr/share/zoneinfo | sed 's/Local time zone must be set--see zic manual page/FCTY/' | "${mysql[@]}" mysql
-		# install TokuDB engine
-		if [ -n "$INIT_TOKUDB" ]; then
-			ps_tokudb_admin --force-mycnf --enable
-		fi
+                # sed is for https://bugs.mysql.com/bug.php?id=20545
+                mysql_tzinfo_to_sql /usr/share/zoneinfo | sed 's/Local time zone must be set--see zic manual page/FCTY/' | "${mysql[@]}" mysql
+                # install TokuDB engine
+                if [ -n "$INIT_TOKUDB" ] && [ $THP_ENABLED == 0 ]; then
+                        ps_tokudb_admin --force-mycnf --enable
+                fi
 
-		if [ ! -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
-			MYSQL_ROOT_PASSWORD="$(pwmake 128)"
-			echo "GENERATED ROOT PASSWORD: $MYSQL_ROOT_PASSWORD"
-		fi
-		"${mysql[@]}" <<-EOSQL
-			-- What's done in this file shouldn't be replicated
-			--  or products like mysql-fabric won't work
-			SET @@SESSION.SQL_LOG_BIN=0;
-			CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
-			GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
-		        ALTER USER 'root'@'localhost' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
-			DROP DATABASE IF EXISTS test ;
-			FLUSH PRIVILEGES ;
-		EOSQL
-		if [ ! -z "$MYSQL_ROOT_PASSWORD" ]; then
-			mysql+=( -p"${MYSQL_ROOT_PASSWORD}" )
-		fi
+                if [ ! -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+                        MYSQL_ROOT_PASSWORD="$(pwmake 128)"
+                        echo "GENERATED ROOT PASSWORD: $MYSQL_ROOT_PASSWORD"
+                fi
+                "${mysql[@]}" <<-EOSQL
+                        -- What's done in this file shouldn't be replicated
+                        --  or products like mysql-fabric won't work
+                        SET @@SESSION.SQL_LOG_BIN=0;
+                        CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+                        GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
+                        ALTER USER 'root'@'localhost' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
+                        DROP DATABASE IF EXISTS test ;
+                        FLUSH PRIVILEGES ;
+                EOSQL
+                if [ ! -z "$MYSQL_ROOT_PASSWORD" ]; then
+                        mysql+=( -p"${MYSQL_ROOT_PASSWORD}" )
+                fi
 
-		if [ "$MYSQL_DATABASE" ]; then
-			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" | "${mysql[@]}"
-			mysql+=( "$MYSQL_DATABASE" )
-		fi
+                if [ "$MYSQL_DATABASE" ]; then
+                        echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" | "${mysql[@]}"
+                        mysql+=( "$MYSQL_DATABASE" )
+                fi
 
-		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
-			echo "CREATE USER '"$MYSQL_USER"'@'%' IDENTIFIED BY '"$MYSQL_PASSWORD"' ;" | "${mysql[@]}"
+                if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
+                        echo "CREATE USER '"$MYSQL_USER"'@'%' IDENTIFIED BY '"$MYSQL_PASSWORD"' ;" | "${mysql[@]}"
 
-			if [ "$MYSQL_DATABASE" ]; then
-				echo "GRANT ALL ON \`"$MYSQL_DATABASE"\`.* TO '"$MYSQL_USER"'@'%' ;" | "${mysql[@]}"
-			fi
+                        if [ "$MYSQL_DATABASE" ]; then
+                                echo "GRANT ALL ON \`"$MYSQL_DATABASE"\`.* TO '"$MYSQL_USER"'@'%' ;" | "${mysql[@]}"
+                        fi
 
-			echo 'FLUSH PRIVILEGES ;' | "${mysql[@]}"
-		fi
+                        echo 'FLUSH PRIVILEGES ;' | "${mysql[@]}"
+                fi
 
-		if [ ! -z "$MYSQL_ONETIME_PASSWORD" ]; then
-			"${mysql[@]}" <<-EOSQL
-				ALTER USER 'root'@'%' PASSWORD EXPIRE;
-			EOSQL
-		fi
-		if ! kill -s TERM "$pid" || ! wait "$pid"; then
-			echo >&2 'MySQL init process failed.'
-			exit 1
-		fi
+                if [ ! -z "$MYSQL_ONETIME_PASSWORD" ]; then
+                        "${mysql[@]}" <<-EOSQL
+                                ALTER USER 'root'@'%' PASSWORD EXPIRE;
+                        EOSQL
+                fi
+                if ! kill -s TERM "$pid" || ! wait "$pid"; then
+                        echo >&2 'MySQL init process failed.'
+                        exit 1
+                fi
 
-		echo
-		echo 'MySQL init process done. Ready for start up.'
-		echo
-		#mv /etc/my.cnf $DATADIR
-	fi
+                echo
+                echo 'MySQL init process done. Ready for start up.'
+                echo
+                #mv /etc/my.cnf $DATADIR
+        fi
 
 exec mysqld $CMDARG

--- a/pxc-57/entrypoint.sh
+++ b/pxc-57/entrypoint.sh
@@ -14,6 +14,11 @@ fi
 	# Get config
 	DATADIR="$("mysqld" --verbose --wsrep_provider= --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 
+	# if we have CLUSTER_JOIN - then we do not need to perform datadir initialize
+	# the data will be copied from another node
+
+	if [ -z "$CLUSTER_JOIN" ]; then
+
 	if [ ! -e "$DATADIR/mysql" ]; then
 		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
                         echo >&2 'error: database is uninitialized and password option is not specified '
@@ -101,6 +106,7 @@ fi
 		#mv /etc/my.cnf $DATADIR
 	fi
 	chown -R mysql:mysql "$DATADIR"
+	fi
 
 if [ -z "$DISCOVERY_SERVICE" ]; then
 	cluster_join=$CLUSTER_JOIN


### PR DESCRIPTION
`mysql@602ed567fe25:/$ mysql -u root -p                                                                        
Enter password: 
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 3
Server version: 5.7.17-13 Percona Server (GPL), Release '13', Revision 'fd33d43'

Copyright (c) 2009-2016 Percona LLC and/or its affiliates
Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> show engines;
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+
| Engine             | Support | Comment                                                                    | Transactions | XA   | Savepoints |
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+
| MyISAM             | YES     | MyISAM storage engine                                                      | NO           | NO   | NO         |
| CSV                | YES     | CSV storage engine                                                         | NO           | NO   | NO         |
| PERFORMANCE_SCHEMA | YES     | Performance Schema                                                         | NO           | NO   | NO         |
| BLACKHOLE          | YES     | /dev/null storage engine (anything you write to it disappears)             | NO           | NO   | NO         |
| MRG_MYISAM         | YES     | Collection of identical MyISAM tables                                      | NO           | NO   | NO         |
| TokuDB             | YES     | Percona TokuDB Storage Engine with Fractal Tree(tm) Technology             | YES          | YES  | YES        |
| InnoDB             | DEFAULT | Percona-XtraDB, Supports transactions, row-level locking, and foreign keys | YES          | YES  | YES        |
| ARCHIVE            | YES     | Archive storage engine                                                     | NO           | NO   | NO         |
| MEMORY             | YES     | Hash based, stored in memory, useful for temporary tables                  | NO           | NO   | NO         |
| FEDERATED          | NO      | Federated MySQL storage engine                                             | NULL         | NULL | NULL       |
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+
10 rows in set (0.00 sec)

mysql> Bye
`

`root@jessie:/home/vagrant/percona-docker/percona-server.56# docker exec -it 3d25a09898d4 /bin/bash
mysql@3d25a09898d4:/$ mysql -u root -p                                                                        
Enter password: 
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 1
Server version: 5.6.35-81.0 Percona Server (GPL), Release 81.0, Revision c96c427

Copyright (c) 2009-2016 Percona LLC and/or its affiliates
Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> show engines;
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+
| Engine             | Support | Comment                                                                    | Transactions | XA   | Savepoints |
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+
| PERFORMANCE_SCHEMA | YES     | Performance Schema                                                         | NO           | NO   | NO         |
| CSV                | YES     | CSV storage engine                                                         | NO           | NO   | NO         |
| MRG_MYISAM         | YES     | Collection of identical MyISAM tables                                      | NO           | NO   | NO         |
| BLACKHOLE          | YES     | /dev/null storage engine (anything you write to it disappears)             | NO           | NO   | NO         |
| MEMORY             | YES     | Hash based, stored in memory, useful for temporary tables                  | NO           | NO   | NO         |
| TokuDB             | YES     | Percona TokuDB Storage Engine with Fractal Tree(tm) Technology             | YES          | YES  | YES        |
| MyISAM             | YES     | MyISAM storage engine                                                      | NO           | NO   | NO         |
| ARCHIVE            | YES     | Archive storage engine                                                     | NO           | NO   | NO         |
| InnoDB             | DEFAULT | Percona-XtraDB, Supports transactions, row-level locking, and foreign keys | YES          | YES  | YES        |
| FEDERATED          | NO      | Federated MySQL storage engine                                             | NULL         | NULL | NULL       |
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+
10 rows in set (0.00 sec)

mysql> Bye
`