### PR TITLE
Support for Password Files added

### DIFF
--- a/percona-server/README.md
+++ b/percona-server/README.md
@@ -48,6 +48,10 @@ Most of the variables listed below are optional, but one of the variables `MYSQL
 
 This variable specifies a password that will be set for the root superuser account. In the above example, it was set to `secret`. **NOTE:** Setting the MySQL root user password on the command line is insecure.
 
+## `MYSQL_ROOT_PASSWORD_FILE`
+
+This variable specifies a file that will be read for the root user account. This can be a mounted file when you run your container. This can also be used in the scope of the Docker Secrets (Swarm mode) functionality.
+
 ## `MYSQL_RANDOM_ROOT_PASSWORD`
 
 When this variable is set to `yes`, a random password for the server's root user will be generated. The password will be printed to stdout in the container, and it can be obtained by using the command `docker logs container-name`.

--- a/percona-server/ps-entry.sh
+++ b/percona-server/ps-entry.sh
@@ -16,16 +16,18 @@ fi
 	DATADIR="$("mysqld" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 
 	if [ ! -d "$DATADIR/mysql" ]; then
-		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" -a -z "MYSQL_ROOT_PASSWORD_FILE" ]; then
+		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" -a -z "$MYSQL_ROOT_PASSWORD_FILE" ]; then
                         echo >&2 'error: database is uninitialized and password option is not specified '
-                        echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD or MYSQL_RANDOM_ROOT_PASSWORD'
+                        echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ROOT_PASSWORD_FILE,  MYSQL_ALLOW_EMPTY_PASSWORD or MYSQL_RANDOM_ROOT_PASSWORD'
                         exit 1
                 fi
 
-		if [[ ! -z "$MYSQL_ROOT_PASSWORD_FILE" ]]; then
+		if [ ! -z "$MYSQL_ROOT_PASSWORD_FILE" -a -z "$MYSQL_ROOT_PASSWORD" ]; then
 		  MYSQL_ROOT_PASSWORD=$(cat $MYSQL_ROOT_PASSWORD_FILE)
-			## DEBUG REMOVE THIS
-			echo "$MYSQL_ROOT_PASSWORD"
+		fi
+
+		if [ ! -z "$XTRABACKUP_PASSWORD_FILE" ]; then
+		  XTRABACKUP_PASSWORD=$(cat $XTRABACKUP_PASSWORD_FILE)
 		fi
 
 		mkdir -p "$DATADIR"

--- a/percona-server/ps-entry.sh
+++ b/percona-server/ps-entry.sh
@@ -26,10 +26,6 @@ fi
 		  MYSQL_ROOT_PASSWORD=$(cat $MYSQL_ROOT_PASSWORD_FILE)
 		fi
 
-		if [ ! -z "$XTRABACKUP_PASSWORD_FILE" ]; then
-		  XTRABACKUP_PASSWORD=$(cat $XTRABACKUP_PASSWORD_FILE)
-		fi
-
 		mkdir -p "$DATADIR"
 
 		echo "Running --initialize-insecure datadir: $DATADIR"

--- a/percona-server/ps-entry.sh
+++ b/percona-server/ps-entry.sh
@@ -16,11 +16,18 @@ fi
 	DATADIR="$("mysqld" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 
 	if [ ! -d "$DATADIR/mysql" ]; then
-		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" -a -z "MYSQL_ROOT_PASSWORD_FILE" ]; then
                         echo >&2 'error: database is uninitialized and password option is not specified '
-                        echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD and MYSQL_RANDOM_ROOT_PASSWORD'
+                        echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD or MYSQL_RANDOM_ROOT_PASSWORD'
                         exit 1
                 fi
+
+		if [[ ! -z "$MYSQL_ROOT_PASSWORD_FILE" ]]; then
+		  MYSQL_ROOT_PASSWORD=$(cat $MYSQL_ROOT_PASSWORD_FILE)
+			## DEBUG REMOVE THIS
+			echo "$MYSQL_ROOT_PASSWORD"
+		fi
+
 		mkdir -p "$DATADIR"
 
 		echo "Running --initialize-insecure datadir: $DATADIR"


### PR DESCRIPTION
I've added some tests for a password file (MYSQL_ROOT_PASSWORD_FILE) that would be read for passwords upon startup. This adds the required functionality to support docker secrets when using Docker Swarm Mode. 