### PR TITLE
Slient Build and added support to Docker Secrets pxc56

### DIFF
--- a/pxc-56/entrypoint.sh
+++ b/pxc-56/entrypoint.sh
@@ -15,11 +15,16 @@ fi
 	DATADIR="$("mysqld" --verbose --wsrep_on=OFF --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 
 	if [ ! -e "$DATADIR/init.ok" ]; then
-		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" -a -z "$MYSQL_ROOT_PASSWORD_FILE" ]; then
                         echo >&2 'error: database is uninitialized and password option is not specified '
-                        echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD and MYSQL_RANDOM_ROOT_PASSWORD'
+                        echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ROOT_PASSWORD_FILE,  MYSQL_ALLOW_EMPTY_PASSWORD or MYSQL_RANDOM_ROOT_PASSWORD'
                         exit 1
                 fi
+
+		if [ ! -z "$MYSQL_ROOT_PASSWORD_FILE" -a -z "$MYSQL_ROOT_PASSWORD" ]; then
+		  MYSQL_ROOT_PASSWORD=$(cat $MYSQL_ROOT_PASSWORD_FILE)
+		fi
+
 		mkdir -p "$DATADIR"
 		chown -R mysql:mysql "$DATADIR"
 

--- a/pxc-57/Dockerfile
+++ b/pxc-57/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Percona Development <info@percona.com>
 
 RUN groupadd -r mysql && useradd -r -g mysql mysql
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update -qq && apt-get install -qqy --no-install-recommends \
 		apt-transport-https ca-certificates \
 		pwgen wget \
 	&& rm -rf /var/lib/apt/lists/*
@@ -16,8 +16,8 @@ RUN wget https://repo.percona.com/apt/percona-release_0.1-4.jessie_all.deb \
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN     apt-get update \
-	&& apt-get install -y --force-yes \
+RUN     apt-get update -qq \
+	&& apt-get install -qqy --force-yes \
 		percona-xtradb-cluster-57 curl \
 	&& rm -rf /var/lib/apt/lists/* \
 # comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)


### PR DESCRIPTION
This PR make the build more silent and adds support to MYSQL_ROOT_PASSWORD_FILE
to pxc-56