### PR TITLE
Fix/mysql random root password

### DIFF
--- a/percona-server/Dockerfile
+++ b/percona-server/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Percona Development <info@percona.com>
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
                 apt-transport-https ca-certificates \
-                pwgen \
+                libpwquality-tools cracklib-runtime \
         && rm -rf /var/lib/apt/lists/*
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 8507EFA5

--- a/percona-server/ps-entry.sh
+++ b/percona-server/ps-entry.sh
@@ -72,7 +72,7 @@ fi
                         ALTER USER 'root'@'localhost' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
                         DROP DATABASE IF EXISTS test ;
                         FLUSH PRIVILEGES ;
-                EOSQL
+				EOSQL
                 if [ ! -z "$MYSQL_ROOT_PASSWORD" ]; then
                         mysql+=( -p"${MYSQL_ROOT_PASSWORD}" )
                 fi
@@ -95,7 +95,7 @@ fi
                 if [ ! -z "$MYSQL_ONETIME_PASSWORD" ]; then
                         "${mysql[@]}" <<-EOSQL
                                 ALTER USER 'root'@'%' PASSWORD EXPIRE;
-                        EOSQL
+						EOSQL
                 fi
                 if ! kill -s TERM "$pid" || ! wait "$pid"; then
                         echo >&2 'MySQL init process failed.'


### PR DESCRIPTION
# /entrypoint.sh: line 63: pwmake: command not found
percona/percona-server:5.7 is can not start using MYSQL_RANDOM_ROOT_PASSWORD=yes.
Error message is below.
/entrypoint.sh: line 63: pwmake: command not found

Debian:jessie is need to install not pwgen but libpwquality-tools and cracklib-runtime.
So, apt get-install pwgen  in Dockerfile replace with  libpwquality-tools and cracklib-runtime .

# Indenting heredoc
The end of heredoc must use tabs, not spaces to indent in ps-entry.sh.