### PR TITLE
Duplicated `--pidfile` during init if passed to mongod at startup

### DIFF
--- a/percona-server-mongodb.36/ps-entry.sh
+++ b/percona-server-mongodb.36/ps-entry.sh
@@ -310,7 +310,7 @@ if [ "$originalArgOne" = 'mongod' ]; then
                         echo
                 done
 
-                "$@" --pidfilepath="$pidfile" --shutdown
+                "${mongodHackedArgs[@]}" --shutdown
                 rm -f "$pidfile"
 
                 echo


### PR DESCRIPTION
I'm passing --pidfilepath=/data/tmp/mongod.pid. When init is finished and mongod is shutdown, this parameter becomes duplicated. 

It's the same as this PR: https://github.com/docker-library/mongo/pull/298 