### PR TITLE
BLD-1195 fix config mount

### DIFF
--- a/percona-server.57/Dockerfile
+++ b/percona-server.57/Dockerfile
@@ -41,7 +41,7 @@ RUN /usr/bin/install -m 0775 -o mysql -g root -d /var/lib/mysql /var/run/mysqld 
 	&& echo "LD_PRELOAD=/usr/lib64/libjemalloc.so.1" >> /etc/sysconfig/mysql \
 	&& echo "THP_SETTING=never" >> /etc/sysconfig/mysql \
 # keep backward compatibility with debian images
-	&& ln -s /etc /etc/mysql \
+	&& ln -s /etc/my.cnf.d /etc/mysql \
 # allow to change config files
 	&& chown -R mysql:root /etc/percona-server.cnf /etc/percona-server.conf.d /etc/my.cnf.d \
 	&& chmod -R ug+rwX /etc/percona-server.cnf /etc/percona-server.conf.d /etc/my.cnf.d

--- a/percona-server.57/Dockerfile-dockerhub
+++ b/percona-server.57/Dockerfile-dockerhub
@@ -41,7 +41,7 @@ RUN /usr/bin/install -m 0775 -o mysql -g root -d /var/lib/mysql /var/run/mysqld 
 	&& echo "LD_PRELOAD=/usr/lib64/libjemalloc.so.1" >> /etc/sysconfig/mysql \
 	&& echo "THP_SETTING=never" >> /etc/sysconfig/mysql \
 # keep backward compatibility with debian images
-	&& ln -s /etc /etc/mysql \
+	&& ln -s /etc/my.cnf.d /etc/mysql \
 # allow to change config files
 	&& chown -R mysql:root /etc/percona-server.cnf /etc/percona-server.conf.d /etc/my.cnf.d \
 	&& chmod -R ug+rwX /etc/percona-server.cnf /etc/percona-server.conf.d /etc/my.cnf.d


### PR DESCRIPTION
some users mount mysql configs to `/etc/mysql` dir.
after migration to centos - `/etc/mysql` dir become sym-link, due to docker behavior, configs become mounted to /etc dir (see https://github.com/moby/moby/issues/17944).
in result some files in `/etc` become unavailable (see https://github.com/presslabs/mysql-operator/pull/167)