### PR TITLE
Lowcase rpm names

### DIFF
--- a/percona-server-mongodb.40/Dockerfile
+++ b/percona-server-mongodb.40/Dockerfile
@@ -22,10 +22,10 @@ ENV K8S_TOOLS_VERSION 0.4.1
 
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
         && yum install -y \
-                Percona-Server-MongoDB-server-${PERCONA_VERSION} \
-                Percona-Server-MongoDB-mongos-${PERCONA_VERSION} \
-                Percona-Server-MongoDB-shell-${PERCONA_VERSION} \
-                Percona-Server-MongoDB-tools-${PERCONA_VERSION} \
+                percona-server-mongodb-server-${PERCONA_VERSION} \
+                percona-server-mongodb-mongos-${PERCONA_VERSION} \
+                percona-server-mongodb-shell-${PERCONA_VERSION} \
+                percona-server-mongodb-tools-${PERCONA_VERSION} \
                 curl \
                 jq \
         && yum clean all \


### PR DESCRIPTION
testing perconalab/percona-server-mongodb:4.0.4
	'utc' [1/6]...passed
	'cve-2014--shellshock' [2/6]...passed
	'no-hard-coded-passwords' [3/6]...passed
	'override-cmd' [4/6]...passed
	'mongo-basics' [5/6]...warning: the current Docker daemon does not appear to support seccomp
.passed
	'mongo-auth-basics' [6/6]...warning: the current Docker daemon does not appear to support seccomp
.passed