### PR TITLE
Set version due to latest decisions

### DIFF
--- a/percona-server-mongodb.40/Dockerfile
+++ b/percona-server-mongodb.40/Dockerfile
@@ -17,7 +17,7 @@ RUN useradd -u 1001 -r -g 0 -s /sbin/nologin \
             -c "Default Application User" mongodb
 
 ENV PERCONA_MAJOR 40
-ENV PERCONA_VERSION 4.0.4-1.0.el7
+ENV PERCONA_VERSION 4.0.4-1.el7
 ENV K8S_TOOLS_VERSION 0.4.1
 
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \


### PR DESCRIPTION
        'utc' [1/6]...passed
        'cve-2014--shellshock' [2/6]...passed
        'no-hard-coded-passwords' [3/6]...passed
        'override-cmd' [4/6]...passed
        'mongo-basics' [5/6]...warning: the current Docker daemon does not appear to support seccomp
.passed
        'mongo-auth-basics' [6/6]...warning: the current Docker daemon does not appear to support seccomp
..passed
