### PR TITLE
Ignore password set in the .cnf file when first initializing MySQL

### DIFF
--- a/percona-server.57/ps-entry.sh
+++ b/percona-server.57/ps-entry.sh
@@ -117,7 +117,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		"$@" --skip-networking --socket="${SOCKET}" &
 		pid="$!"
 
-		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" )
+		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" --password="" )
 
 		for i in {120..0}; do
 			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then

--- a/percona-server.80/ps-entry.sh
+++ b/percona-server.80/ps-entry.sh
@@ -117,7 +117,7 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		"$@" --skip-networking --socket="${SOCKET}" &
 		pid="$!"
 
-		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" )
+		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" --password="" )
 
 		for i in {120..0}; do
 			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then

--- a/test/tests/mysql-conf-mount/conf.d/client.cnf
+++ b/test/tests/mysql-conf-mount/conf.d/client.cnf
@@ -1,0 +1,3 @@
+[client]
+user = root
+password = some-password


### PR DESCRIPTION
When the client is configured in `my.cnf`, and a password is specified, then MySQL initialization fails. This is a problem, now, because of the new image based on CenOS, that has the `/etc/my.cnf` file which includes all `*.cnf` files from `/etc/mysql`. Therefore `/etc/mysql/client.cnf` is loaded at initialization time, and the client fails to connect with the error:
```
2019-04-17T20:32:03.026406Z 3 [Note] Access denied for user 'root'@'localhost' (using password: YES)
MySQL init process in progress...
```

A solution is to explicitly specify the empty password to the MySQL client. Not sure if this covers all the cases,  there is another solution, to use `--no-defaults` client flag.

Thank you!