### PR TITLE
CLOUD-220 Mongod ssl startup fix

### DIFF
--- a/percona-server-mongodb.36/ps-entry.sh
+++ b/percona-server-mongodb.36/ps-entry.sh
@@ -241,9 +241,6 @@ if [ "$originalArgOne" = 'mongod' ]; then
 			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"
 		fi
 
-		sslMode="$(_mongod_hack_have_arg '--sslPEMKeyFile' "$@" && echo 'preferSSL' || echo 'disabled')" # "BadValue: need sslPEMKeyFile when SSL is enabled" vs "BadValue: need to enable SSL via the sslMode flag when using SSL configuration parameters"
-		_mongod_hack_ensure_arg_val --sslMode "$sslMode" "${mongodHackedArgs[@]}"
-
 		if stat "/proc/$$/fd/1" > /dev/null && [ -w "/proc/$$/fd/1" ]; then
 			# https://github.com/mongodb/mongo/blob/38c0eb538d0fd390c6cb9ce9ae9894153f6e8ef5/src/mongo/db/initialize_server_global_state.cpp#L237-L251
 			# https://github.com/docker-library/mongo/issues/164#issuecomment-293965668

--- a/percona-server-mongodb.36/ps-entry.sh
+++ b/percona-server-mongodb.36/ps-entry.sh
@@ -346,6 +346,10 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		set -- "${mongodHackedArgs[@]}"
 	fi
 
+	sslMode="$(_mongod_hack_have_arg '--sslPEMKeyFile' "$@" && echo 'preferSSL' || echo 'disabled')" # "BadValue: need sslPEMKeyFile when SSL is enabled" vs "BadValue: need to enable SSL via the sslMode flag when using SSL configuration parameters"
+	_mongod_hack_ensure_arg_val --sslMode "$sslMode" "$@"
+	set -- "${mongodHackedArgs[@]}"
+
 	# MongoDB 3.6+ defaults to localhost-only binding
 	haveBindIp=
 	if _mongod_hack_have_arg --bind_ip "$@" || _mongod_hack_have_arg --bind_ip_all "$@"; then

--- a/percona-server-mongodb.40/ps-entry.sh
+++ b/percona-server-mongodb.40/ps-entry.sh
@@ -241,9 +241,6 @@ if [ "$originalArgOne" = 'mongod' ]; then
 			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"
 		fi
 
-		sslMode="$(_mongod_hack_have_arg '--sslPEMKeyFile' "$@" && echo 'preferSSL' || echo 'disabled')" # "BadValue: need sslPEMKeyFile when SSL is enabled" vs "BadValue: need to enable SSL via the sslMode flag when using SSL configuration parameters"
-		_mongod_hack_ensure_arg_val --sslMode "$sslMode" "${mongodHackedArgs[@]}"
-
 		if stat "/proc/$$/fd/1" > /dev/null && [ -w "/proc/$$/fd/1" ]; then
 			# https://github.com/mongodb/mongo/blob/38c0eb538d0fd390c6cb9ce9ae9894153f6e8ef5/src/mongo/db/initialize_server_global_state.cpp#L237-L251
 			# https://github.com/docker-library/mongo/issues/164#issuecomment-293965668
@@ -345,6 +342,10 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		fi
 		set -- "${mongodHackedArgs[@]}"
 	fi
+
+	sslMode="$(_mongod_hack_have_arg '--sslPEMKeyFile' "$@" && echo 'preferSSL' || echo 'disabled')" # "BadValue: need sslPEMKeyFile when SSL is enabled" vs "BadValue: need to enable SSL via the sslMode flag when using SSL configuration parameters"
+	_mongod_hack_ensure_arg_val --sslMode "$sslMode" "$@"
+	set -- "${mongodHackedArgs[@]}"
 
 	# MongoDB 3.6+ defaults to localhost-only binding
 	haveBindIp=


### PR DESCRIPTION
Kubernetes mongo operator can't start mongod in unsafe mode
due to the lack of sslMode option, which is not set by the
entrypoint script properly.