### PR TITLE
Switched from hostname -i to hostname -I 

### DIFF
--- a/percona-server-master-slave/master_nc
+++ b/percona-server-master-slave/master_nc
@@ -8,7 +8,7 @@
 #Timeout exists for instances where mysqld may be hung
 TIMEOUT=10
 
-ipaddr=$(hostname -i | awk ' { print $1 } ')
+ipaddr=$(hostname -I | awk ' { print $1 } ')
 hostname=$(hostname)
 
 while true

--- a/percona-server-master-slave/ps-entry.sh
+++ b/percona-server-master-slave/ps-entry.sh
@@ -7,7 +7,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 #get server_id from ip address
-ipaddr=$(hostname -i | awk ' { print $1 } ')
+ipaddr=$(hostname -I | awk ' { print $1 } ')
 server_id=$(echo $ipaddr | tr . '\n' | awk '{s = s*256 + $1} END{print s}')
 
 if [ -z "$MASTER_HOST" ]; then

--- a/pgr-57/clustercheckcron
+++ b/pgr-57/clustercheckcron
@@ -43,7 +43,7 @@ else
     MYSQL_CMDLINE="mysql -nNE --connect-timeout=$TIMEOUT ${EXTRA_ARGS}"
 fi
 
-ipaddr=$(hostname -i | awk ' { print $1 } ')
+ipaddr=$(hostname -I | awk ' { print $1 } ')
 hostname=$(hostname)
 
 while true

--- a/pgr-57/entrypoint.sh
+++ b/pgr-57/entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 USER_ID=$(id -u)
 
-ipaddr=$(hostname -i | awk ' { print $1 } ')
+ipaddr=$(hostname -I | awk ' { print $1 } ')
 hostname=$(hostname)
 
 echo "loose-group_replication_local_address=$hostname:24901" >> /etc/mysql/conf.d/node.cnf

--- a/proxysql/dockerdir/usr/bin/add_cluster_nodes.sh
+++ b/proxysql/dockerdir/usr/bin/add_cluster_nodes.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ipaddr=$(hostname -i | awk ' { print $1 } ')
+ipaddr=$(hostname -I | awk ' { print $1 } ')
 
 for i in $(curl http://$DISCOVERY_SERVICE/v2/keys/pxc-cluster/$CLUSTER_NAME/ | jq -r '.node.nodes[]?.key' | awk -F'/' '{print $(NF)}')
 do

--- a/pxc-56/clustercheckcron
+++ b/pxc-56/clustercheckcron
@@ -43,7 +43,7 @@ else
     MYSQL_CMDLINE="mysql -nNE --connect-timeout=$TIMEOUT ${EXTRA_ARGS}"
 fi
 
-ipaddr=$(hostname -i | awk ' { print $1 } ')
+ipaddr=$(hostname -I | awk ' { print $1 } ')
 hostname=$(hostname)
 
 while true

--- a/pxc-56/entrypoint.sh
+++ b/pxc-56/entrypoint.sh
@@ -118,7 +118,7 @@ else
 # Read the list of registered IP addresses
     set +e
 
-    ipaddr=$(hostname -i | awk ' { print $1 } ')
+    ipaddr=$(hostname -I | awk ' { print $1 } ')
     hostname=$(hostname)
 
     curl http://$DISCOVERY_SERVICE/v2/keys/pxc-cluster/queue/$CLUSTER_NAME -XPOST -d value=$ipaddr -d ttl=60

--- a/pxc-57/dockerdir/usr/bin/clustercheckcron
+++ b/pxc-57/dockerdir/usr/bin/clustercheckcron
@@ -43,7 +43,7 @@ else
     MYSQL_CMDLINE="mysql -nNE --connect-timeout=$TIMEOUT ${EXTRA_ARGS}"
 fi
 
-ipaddr=$(hostname -i | awk ' { print $1 } ')
+ipaddr=$(hostname -I | awk ' { print $1 } ')
 hostname=$(hostname)
 
 while true

--- a/pxc-57/dockerdir/usr/bin/configure-pxc.sh
+++ b/pxc-57/dockerdir/usr/bin/configure-pxc.sh
@@ -26,7 +26,7 @@ function join {
     local IFS="$1"; shift; echo "$*";
 }
 
-NODE_IP=$(hostname -i)
+NODE_IP=$(hostname -I)
 CLUSTER_NAME="$(hostname -f | cut -d'.' -f2)"
 SERVER_ID=${HOSTNAME/$CLUSTER_NAME-}
 


### PR DESCRIPTION
From man pages:
"-i, --ip-address Display the IP address(es) of the host. Note that this works only if the host name can be resolved. Avoid using this option; use hostname --all-ip-addresses instead." 
-I is shorthand for --all-ip-addresses.