### PR TITLE
CLOUD-429: Use mysql_native_password

### DIFF
--- a/pxc-80/dockerdir/etc/mysql/node.cnf
+++ b/pxc-80/dockerdir/etc/mysql/node.cnf
@@ -1,4 +1,5 @@
 [mysqld]
+default_authentication_plugin=mysql_native_password
 datadir=/var/lib/mysql
 socket=/tmp/mysql.sock
 pid-file=/var/run/mysqld/mysqld.pid


### PR DESCRIPTION
This is needed to make ProxySQL work