### PR TITLE
wait for wsrep_local_state_comment to be Sync

### DIFF
--- a/pxc-57/dockerdir/entrypoint.sh
+++ b/pxc-57/dockerdir/entrypoint.sh
@@ -178,11 +178,10 @@ if [ -z "$CLUSTER_JOIN" ] && [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		pid="$!"
 
 		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" --password="" )
-		mysql_select=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" --password="" -s )
 		wsrep_local_state_select="SELECT variable_value FROM performance_schema.global_status WHERE variable_name='wsrep_local_state_comment'"
 
 		for i in {120..0}; do
-			wsrep_local_state=$(echo "$wsrep_local_state_select" | "${mysql_select[@]}" &> /dev/null) || true
+			wsrep_local_state=$(echo "$wsrep_local_state_select" | "${mysql[@]}" -s &> /dev/null) || true
 			if [ "$wsrep_local_state" = 'Synced' ]; then
 				break
 			fi

--- a/pxc-57/dockerdir/entrypoint.sh
+++ b/pxc-57/dockerdir/entrypoint.sh
@@ -178,9 +178,12 @@ if [ -z "$CLUSTER_JOIN" ] && [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		pid="$!"
 
 		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" --password="" )
+		mysql_select=( mysql --protocol=socket -uroot -hlocalhost --socket="${SOCKET}" --password="" -s )
+		wsrep_local_state_select="SELECT variable_value FROM performance_schema.global_status WHERE variable_name='wsrep_local_state_comment'"
 
 		for i in {120..0}; do
-			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
+			wsrep_local_state=$(echo "$wsrep_local_state_select" | "${mysql_select[@]}" &> /dev/null) || true
+			if [ "$wsrep_local_state" = 'Synced' ]; then
 				break
 			fi
 			echo 'MySQL init process in progress...'

--- a/test/detect-images.sh
+++ b/test/detect-images.sh
@@ -8,6 +8,9 @@ pathToTests=$(dirname $0)
 echo "Changed files between $@:"
 for file in $(git --no-pager diff --name-only "$@"); do
 	dir=$(dirname $file)
+	if [ $(basename $dir) = "dockerdir" ]; then
+		dir=$(dirname $dir)
+	fi
 	echo -- $file
 	if [ -d "$file" -a -f "$file/Dockerfile" ]; then
 		dockerfilePaths["$file"]=1

--- a/test/detect-images.sh
+++ b/test/detect-images.sh
@@ -7,10 +7,7 @@ pathToTests=$(dirname $0)
 
 echo "Changed files between $@:"
 for file in $(git --no-pager diff --name-only "$@"); do
-	dir=$(dirname $file)
-	if [ $(basename $dir) = "dockerdir" ]; then
-		dir=$(dirname $dir)
-	fi
+	dir=$(dirname $file | cut -d '/' -f 1)
 	echo -- $file
 	if [ -d "$file" -a -f "$file/Dockerfile" ]; then
 		dockerfilePaths["$file"]=1


### PR DESCRIPTION
According to https://jira.percona.com/browse/PXC-2168

> The problems seems to occur if you execute a writer operation too quickly after starting a Galera node - even bootstrapping a single node cluster with --wsrep-new-cluster. There seems to be a few millisecond race window between MySQL accepting connections and when Galera is actually initialized and won't abort queries with deadlock errors.

> We worked around in our environments by waiting for wsrep_local_state_comment == 'Synced' before attempting any node initialization which seems to have made our flakes go away in our (non-Docker) CI environments. We recently encountered a similar bug when running integration tests using the percona/percona-xtradb-cluster docker image - we think it's probably the same thing.

Basically I changed `SELECT 1` to `SELECT variable_value FROM performance_schema.global_status WHERE variable_name='wsrep_local_state_comment'`

This change is enough for me (I only use this specific image), but I can see there are couple more places that could be changed (bits waiting for mysql) with some modifications (for example 5.6 should probably use INFORMATION_SCHEMA)

Let me know if this change is acceptable and if other implementations should be changed - I can update this PR.