### PR TITLE
discard only stderr when waiting for database to by synced

### DIFF
--- a/pxc-57/dockerdir/entrypoint.sh
+++ b/pxc-57/dockerdir/entrypoint.sh
@@ -181,7 +181,7 @@ if [ -z "$CLUSTER_JOIN" ] && [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		wsrep_local_state_select="SELECT variable_value FROM performance_schema.global_status WHERE variable_name='wsrep_local_state_comment'"
 
 		for i in {120..0}; do
-			wsrep_local_state=$(echo "$wsrep_local_state_select" | "${mysql[@]}" -s &> /dev/null) || true
+			wsrep_local_state=$(echo "$wsrep_local_state_select" | "${mysql[@]}" -s 2> /dev/null) || true
 			if [ "$wsrep_local_state" = 'Synced' ]; then
 				break
 			fi


### PR DESCRIPTION
Sorry for creating PR again - I accidentally discarded full output from mysql including selected value, but I should only discard stderr. I thought everything works since tests passed. This time I mounted my version of entrypoint and checked if it works before submitting PR. Sorry for the inconvenience.