### PR TITLE
[PSQLADM-237] Fix gnutls dependency

### DIFF
--- a/proxysql/Dockerfile
+++ b/proxysql/Dockerfile
@@ -39,7 +39,7 @@ RUN yum update -y \
                 hostname \
                 perl-DBD-MySQL \
                 perl-DBI \
-		gnutls \
+                gnutls \
         && yum clean all
 
 RUN groupadd -g 1001 proxysql \

--- a/proxysql/Dockerfile.k8s
+++ b/proxysql/Dockerfile.k8s
@@ -40,7 +40,6 @@ RUN microdnf update -y \
                 yum-utils \
                 perl-DBD-MySQL \
                 perl-DBI \
-		gnutls \
         && microdnf clean all
 
 RUN groupadd -g 1001 proxysql \
@@ -55,8 +54,10 @@ RUN sed -i '/nodocs/d' /etc/yum.conf || : \
         && repoquery -a --location \
                proxysql2-${PROXYSQL_VERSION} \
                    | xargs curl -L -o /tmp/proxysql2-${PROXYSQL_VERSION}.rpm \
-        && rpm -iv /tmp/proxysql2-${PROXYSQL_VERSION}.rpm /tmp/util-linux.rpm --nodeps \
-        && rm -rf /tmp/proxysql2-${PROXYSQL_VERSION}.rpm /tmp/util-linux.rpm \
+        && curl -L -o /tmp/gnutls.rpm http://mirror.centos.org/centos/7/os/x86_64/Packages/gnutls-3.3.29-9.el7_6.x86_64.rpm \
+        && curl -L -o /tmp/nettle.rpm http://mirror.centos.org/centos/7/os/x86_64/Packages/nettle-2.7.1-8.el7.x86_64.rpm \
+        && rpm -iv /tmp/proxysql2-${PROXYSQL_VERSION}.rpm /tmp/util-linux.rpm /tmp/gnutls.rpm /tmp/nettle.rpm --nodeps \
+        && rm -rf /tmp/proxysql2-${PROXYSQL_VERSION}.rpm /tmp/util-linux.rpm /tmp/gnutls.rpm /tmp/nettle.rpm \
         && microdnf remove -y \
                yum-utils \
                python-kitchen \


### PR DESCRIPTION
just to confirm that it works:

```
+ CERT=/etc/proxysql/ssl/tls.crt
+ '[' -f /etc/proxysql/ssl-internal/tls.key ']'
+ '[' -f /var/run/secrets/kubernetes.io/serviceaccount/ca.crt ']'
+ '[' -f /etc/proxysql/ssl/tls.key ']'
+ '[' -f /etc/proxysql/ssl/ca.crt ']'
+ exec /usr/bin/proxysql -f -c /etc/proxysql/proxysql.cnf
2020-03-31 09:22:27 [INFO] Using config file /etc/proxysql/proxysql.cnf
2020-03-31 09:22:27 [INFO] Using OpenSSL version: OpenSSL 1.1.0h  27 Mar 2018
2020-03-31 09:22:27 [INFO] No SSL keys/certificates found in datadir (/var/lib/proxysql). Generating new keys/certificates.
2020-03-31 09:22:27 [INFO] ProxySQL version 2.0.10-percona-1.1
2020-03-31 09:22:27 [INFO] Detected OS: Linux fb2240170adf 4.15.0-54-generic #58-Ubuntu SMP Mon Jun 24 10:55:24 UTC 2019 x86_64
2020-03-31 09:22:27 [INFO] ProxySQL SHA1 checksum: 225445eaa4e1520032bd93f91b3ac503b00c0c60
Standard ProxySQL MySQL Logger rev. 2.0.0714 -- MySQL_Logger.cpp -- Fri Feb 28 13:11:05 2020
Standard ProxySQL Cluster rev. 0.4.0906 -- ProxySQL_Cluster.cpp -- Fri Feb 28 13:11:05 2020
Standard ProxySQL Statistics rev. 1.4.1027 -- ProxySQL_Statistics.cpp -- Fri Feb 28 13:11:05 2020
Standard ProxySQL HTTP Server Handler rev. 1.4.1031 -- ProxySQL_HTTP_Server.cpp -- Fri Feb 28 13:11:05 2020
2020-03-31 09:22:28 ProxySQL_Admin.cpp:5436:flush_mysql_variables___database_to_runtime(): [WARNING] Impossible to set variable server_capabilities with value "569867". Resetting to current "569899".
Standard ProxySQL Admin rev. 2.0.6.0805 -- ProxySQL_Admin.cpp -- Fri Feb 28 13:11:05 2020
2020-03-31 09:22:28 [INFO] ProxySQL SHA1 checksum: 225445eaa4e1520032bd93f91b3ac503b00c0c60
Standard MySQL Threads Handler rev. 0.2.0902 -- MySQL_Thread.cpp -- Fri Feb 28 13:11:05 2020
Standard MySQL Authentication rev. 0.2.0902 -- MySQL_Authentication.cpp -- Fri Feb 28 13:11:05 2020
2020-03-31 09:22:28 [INFO] Dumping mysql_servers_incoming

```