### PR TITLE
Fix 'Could not find OpenSSL on the system' for Percona Server 8

### DIFF
--- a/percona-server.80/Dockerfile
+++ b/percona-server.80/Dockerfile
@@ -30,6 +30,7 @@ RUN set -ex; \
         percona-server-devel-${PERCONA_VERSION} \
         percona-server-rocksdb-${PERCONA_VERSION} \
         jemalloc \
+        openssl \
         which \
         policycoreutils; \
     \


### PR DESCRIPTION
`mysql_ssl_rsa_setup` used in entrypoint script fails due to OpenSSL not being installed.