### PR TITLE
Proxysql config: mysql-stacksize, mysql-interfaces

### DIFF
--- a/proxysql/dockerdir/entrypoint.sh
+++ b/proxysql/dockerdir/entrypoint.sh
@@ -24,6 +24,9 @@ function get_cipher() {
 PROXY_CFG=/etc/proxysql/proxysql.cnf
 PROXY_ADMIN_CFG=/etc/proxysql-admin.cnf
 
+sed "s/interfaces=\"0.0.0.0:3306\"/interfaces=\"${MYSQL_INTERFACES:-0.0.0.0:3306}\"/g" ${PROXY_CFG} 1<> ${PROXY_CFG}
+sed "s/stacksize=1048576/stacksize=${MYSQL_STACKSIZE:-1048576}/g" ${PROXY_CFG} 1<> ${PROXY_CFG}
+
 set +o xtrace # hide sensitive information
 MYSQL_ROOT_PASSWORD_ESCAPED=$(sed 's/[\*\.\@\&\#\?\!]/\\&/g' <<<"${MYSQL_ROOT_PASSWORD}")
 


### PR DESCRIPTION
Allow setting mysql-stacksize and mysql-interfaces via the
environment variables MYSQL_STACKSIZE and MYSQL_INTERFACES
respectively.

These together with mysql-threads are the only global variables
that take effect only after restarting ProxySQL. Therefore it
makes sennse to set them up before a ProxySQL instance first
starts.

Having the freedom to set these options this way allows for
easier scaling in Kubernetes for example.