### PR TITLE
K8SPSMDB-207: unify ps-entry.sh for different mongodb releases

### DIFF
--- a/.github/pr-badge.yml
+++ b/.github/pr-badge.yml
@@ -1,0 +1,5 @@
+label: "JIRA"
+url: "https://jira.percona.com/browse/$issuePrefix"
+message: "$issuePrefix"
+color: "green"
+when: "$issuePrefix"

--- a/percona-server-mongodb.36/ps-entry.sh
+++ b/percona-server-mongodb.36/ps-entry.sh
@@ -136,6 +136,41 @@ _mongod_hack_ensure_arg_val() {
 	mongodHackedArgs+=( "$ensureArg" "$ensureVal" )
 }
 
+# _mongod_hack_rename_arg_save_val '--arg-to-rename' '--arg-to-rename-to' "$@"
+# set -- "${mongodHackedArgs[@]}"
+_mongod_hack_rename_arg_save_val() {
+	local oldArg="$1"; shift
+	local newArg="$1"; shift
+	if ! _mongod_hack_have_arg "$oldArg" "$@"; then
+		return 0
+	fi
+	local val=""
+	mongodHackedArgs=()
+	while [ "$#" -gt 0 ]; do
+		local arg="$1"; shift
+		if [ "$arg" = "$oldArg" ]; then
+			val="$1"; shift
+			continue
+		elif [[ "$arg" =~ "$oldArg"=(.*) ]]; then
+			val=${BASH_REMATCH[1]}
+			continue
+		fi
+		mongodHackedArgs+=("$arg")
+	done
+	mongodHackedArgs+=("$newArg" "$val")
+}
+
+# _mongod_hack_rename_arg'--arg-to-rename' '--arg-to-rename-to' "$@"
+# set -- "${mongodHackedArgs[@]}"
+_mongod_hack_rename_arg() {
+	local oldArg="$1"; shift
+	local newArg="$1"; shift
+	if _mongod_hack_have_arg "$oldArg" "$@"; then
+		_mongod_hack_ensure_no_arg "$oldArg" "$@"
+		_mongod_hack_ensure_arg "$newArg" "${mongodHackedArgs[@]}"
+	fi
+}
+
 # _js_escape 'some "string" value'
 _js_escape() {
 	jq --null-input --arg 'str' "$1" '$str'
@@ -355,6 +390,50 @@ if [ "$originalArgOne" = 'mongod' ]; then
 			_mongod_hack_ensure_arg_val --sslClusterCAFile "${MONGO_SSL_INTERNAL_DIR}/ca.crt" "${mongodHackedArgs[@]}"
 		fi
 	fi
+
+	MONGODB_VERSION=$(mongod --version  | head -1 | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
+
+  if [ '$MONGODB_VERSION' == "v4.2" ]; then
+    _mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
+
+    if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+      tlsMode="none"
+      if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
+        tlsMode='allowTLS'
+      elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
+        tlsMode='preferTLS'
+      elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
+        tlsMode='requireTLS'
+      fi
+
+      if [ "$tlsMode" != "none" ]; then
+        _mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
+        _mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
+      fi
+    fi
+
+    _mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
+    if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+      if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
+        _mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
+      fi
+    fi
+    _mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
+
+
+    _mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
+  fi
 
 	set -- "${mongodHackedArgs[@]}"
 

--- a/percona-server-mongodb.36/ps-entry.sh
+++ b/percona-server-mongodb.36/ps-entry.sh
@@ -396,46 +396,46 @@ if [ "$originalArgOne" = 'mongod' ]; then
 	MONGODB_VERSION=$(mongod --version  | head -1 | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
 
 	if [ '$MONGODB_VERSION' == "v4.2" ]; then
-		_mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
 
-		if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-		tlsMode="none"
-		if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
-			tlsMode='allowTLS'
-		elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
-			tlsMode='preferTLS'
-		elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
-			tlsMode='requireTLS'
+            if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+	        tlsMode="none"
+	        if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
+	            tlsMode='allowTLS'
+	        elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
+	            tlsMode='preferTLS'
+                elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
+	            tlsMode='requireTLS'
+	        fi
+          
+	        if [ "$tlsMode" != "none" ]; then
+	            _mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
+		    _mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
 		fi
+            fi
 
-		if [ "$tlsMode" != "none" ]; then
-			_mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
-			_mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
-		fi
-		fi
-
-		_mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
-		if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-		if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
-			_mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
-		fi
-		fi
-		_mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
+	    if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+	        if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
+	            _mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
+                fi
+            fi
+	    _mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
 
 
-		_mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
-	fi
+	    _mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
+        fi
 
 	set -- "${mongodHackedArgs[@]}"
 

--- a/percona-server-mongodb.36/ps-entry.sh
+++ b/percona-server-mongodb.36/ps-entry.sh
@@ -396,46 +396,46 @@ if [ "$originalArgOne" = 'mongod' ]; then
 	MONGODB_VERSION=$(mongod --version  | head -1 | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
 
 	if [ '$MONGODB_VERSION' == "v4.2" ]; then
-	    _mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
 
-            if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-	        tlsMode="none"
-	        if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
-	            tlsMode='allowTLS'
-	        elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
-	            tlsMode='preferTLS'
-                elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
-	            tlsMode='requireTLS'
-	        fi
+		if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+			tlsMode="none"
+			if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
+				tlsMode='allowTLS'
+			elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
+				tlsMode='preferTLS'
+			elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
+				tlsMode='requireTLS'
+			fi
           
-	        if [ "$tlsMode" != "none" ]; then
-	            _mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
-		    _mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
+			if [ "$tlsMode" != "none" ]; then
+				_mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
+				_mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
+			fi
 		fi
-            fi
 
-	    _mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
-	    if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-	        if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
-	            _mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
-                fi
-            fi
-	    _mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
+		if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+			if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
+				_mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
+			fi
+		fi
+		_mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
 
 
-	    _mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
-        fi
+		_mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
+	fi
 
 	set -- "${mongodHackedArgs[@]}"
 

--- a/percona-server-mongodb.36/ps-entry.sh
+++ b/percona-server-mongodb.36/ps-entry.sh
@@ -136,6 +136,7 @@ _mongod_hack_ensure_arg_val() {
 	mongodHackedArgs+=( "$ensureArg" "$ensureVal" )
 }
 
+# required by mongodb 4.2
 # _mongod_hack_rename_arg_save_val '--arg-to-rename' '--arg-to-rename-to' "$@"
 # set -- "${mongodHackedArgs[@]}"
 _mongod_hack_rename_arg_save_val() {
@@ -160,6 +161,7 @@ _mongod_hack_rename_arg_save_val() {
 	mongodHackedArgs+=("$newArg" "$val")
 }
 
+# required by mongodb 4.2
 # _mongod_hack_rename_arg'--arg-to-rename' '--arg-to-rename-to' "$@"
 # set -- "${mongodHackedArgs[@]}"
 _mongod_hack_rename_arg() {
@@ -393,47 +395,47 @@ if [ "$originalArgOne" = 'mongod' ]; then
 
 	MONGODB_VERSION=$(mongod --version  | head -1 | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
 
-  if [ '$MONGODB_VERSION' == "v4.2" ]; then
-    _mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
+	if [ '$MONGODB_VERSION' == "v4.2" ]; then
+		_mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
 
-    if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-      tlsMode="none"
-      if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
-        tlsMode='allowTLS'
-      elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
-        tlsMode='preferTLS'
-      elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
-        tlsMode='requireTLS'
-      fi
+		if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+		tlsMode="none"
+		if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
+			tlsMode='allowTLS'
+		elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
+			tlsMode='preferTLS'
+		elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
+			tlsMode='requireTLS'
+		fi
 
-      if [ "$tlsMode" != "none" ]; then
-        _mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
-        _mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
-      fi
-    fi
+		if [ "$tlsMode" != "none" ]; then
+			_mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
+			_mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
+		fi
+		fi
 
-    _mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
-    if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-      if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
-        _mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
-      fi
-    fi
-    _mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
+		if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+		if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
+			_mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
+		fi
+		fi
+		_mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
 
 
-    _mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
-  fi
+		_mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
+	fi
 
 	set -- "${mongodHackedArgs[@]}"
 

--- a/percona-server-mongodb.40/ps-entry.sh
+++ b/percona-server-mongodb.40/ps-entry.sh
@@ -136,6 +136,41 @@ _mongod_hack_ensure_arg_val() {
 	mongodHackedArgs+=( "$ensureArg" "$ensureVal" )
 }
 
+# _mongod_hack_rename_arg_save_val '--arg-to-rename' '--arg-to-rename-to' "$@"
+# set -- "${mongodHackedArgs[@]}"
+_mongod_hack_rename_arg_save_val() {
+	local oldArg="$1"; shift
+	local newArg="$1"; shift
+	if ! _mongod_hack_have_arg "$oldArg" "$@"; then
+		return 0
+	fi
+	local val=""
+	mongodHackedArgs=()
+	while [ "$#" -gt 0 ]; do
+		local arg="$1"; shift
+		if [ "$arg" = "$oldArg" ]; then
+			val="$1"; shift
+			continue
+		elif [[ "$arg" =~ "$oldArg"=(.*) ]]; then
+			val=${BASH_REMATCH[1]}
+			continue
+		fi
+		mongodHackedArgs+=("$arg")
+	done
+	mongodHackedArgs+=("$newArg" "$val")
+}
+
+# _mongod_hack_rename_arg'--arg-to-rename' '--arg-to-rename-to' "$@"
+# set -- "${mongodHackedArgs[@]}"
+_mongod_hack_rename_arg() {
+	local oldArg="$1"; shift
+	local newArg="$1"; shift
+	if _mongod_hack_have_arg "$oldArg" "$@"; then
+		_mongod_hack_ensure_no_arg "$oldArg" "$@"
+		_mongod_hack_ensure_arg "$newArg" "${mongodHackedArgs[@]}"
+	fi
+}
+
 # _js_escape 'some "string" value'
 _js_escape() {
 	jq --null-input --arg 'str' "$1" '$str'
@@ -355,6 +390,50 @@ if [ "$originalArgOne" = 'mongod' ]; then
 			_mongod_hack_ensure_arg_val --sslClusterCAFile "${MONGO_SSL_INTERNAL_DIR}/ca.crt" "${mongodHackedArgs[@]}"
 		fi
 	fi
+
+	MONGODB_VERSION=$(mongod --version  | head -1 | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
+
+  if [ '$MONGODB_VERSION' == "v4.2" ]; then
+    _mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
+
+    if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+      tlsMode="none"
+      if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
+        tlsMode='allowTLS'
+      elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
+        tlsMode='preferTLS'
+      elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
+        tlsMode='requireTLS'
+      fi
+
+      if [ "$tlsMode" != "none" ]; then
+        _mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
+        _mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
+      fi
+    fi
+
+    _mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
+    if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+      if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
+        _mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
+      fi
+    fi
+    _mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
+
+
+    _mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
+  fi
 
 	set -- "${mongodHackedArgs[@]}"
 

--- a/percona-server-mongodb.40/ps-entry.sh
+++ b/percona-server-mongodb.40/ps-entry.sh
@@ -396,46 +396,46 @@ if [ "$originalArgOne" = 'mongod' ]; then
 	MONGODB_VERSION=$(mongod --version  | head -1 | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
 
 	if [ '$MONGODB_VERSION' == "v4.2" ]; then
-		_mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
 
-		if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-		tlsMode="none"
-		if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
-			tlsMode='allowTLS'
-		elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
-			tlsMode='preferTLS'
-		elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
-			tlsMode='requireTLS'
+            if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+	        tlsMode="none"
+	        if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
+	            tlsMode='allowTLS'
+	        elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
+	            tlsMode='preferTLS'
+                elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
+	            tlsMode='requireTLS'
+	        fi
+          
+	        if [ "$tlsMode" != "none" ]; then
+	            _mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
+		    _mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
 		fi
+            fi
 
-		if [ "$tlsMode" != "none" ]; then
-			_mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
-			_mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
-		fi
-		fi
-
-		_mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
-		if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-		if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
-			_mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
-		fi
-		fi
-		_mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
+	    if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+	        if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
+	            _mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
+                fi
+            fi
+	    _mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
 
 
-		_mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
-	fi
+	    _mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
+        fi
 
 	set -- "${mongodHackedArgs[@]}"
 

--- a/percona-server-mongodb.40/ps-entry.sh
+++ b/percona-server-mongodb.40/ps-entry.sh
@@ -396,46 +396,46 @@ if [ "$originalArgOne" = 'mongod' ]; then
 	MONGODB_VERSION=$(mongod --version  | head -1 | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
 
 	if [ '$MONGODB_VERSION' == "v4.2" ]; then
-	    _mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
 
-            if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-	        tlsMode="none"
-	        if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
-	            tlsMode='allowTLS'
-	        elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
-	            tlsMode='preferTLS'
-                elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
-	            tlsMode='requireTLS'
-	        fi
+		if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+			tlsMode="none"
+			if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
+				tlsMode='allowTLS'
+			elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
+				tlsMode='preferTLS'
+			elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
+				tlsMode='requireTLS'
+			fi
           
-	        if [ "$tlsMode" != "none" ]; then
-	            _mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
-		    _mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
+			if [ "$tlsMode" != "none" ]; then
+				_mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
+				_mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
+			fi
 		fi
-            fi
 
-	    _mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
-	    if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-	        if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
-	            _mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
-                fi
-            fi
-	    _mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
+		if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+			if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
+				_mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
+			fi
+		fi
+		_mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
 
 
-	    _mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
-        fi
+		_mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
+	fi
 
 	set -- "${mongodHackedArgs[@]}"
 

--- a/percona-server-mongodb.40/ps-entry.sh
+++ b/percona-server-mongodb.40/ps-entry.sh
@@ -136,6 +136,7 @@ _mongod_hack_ensure_arg_val() {
 	mongodHackedArgs+=( "$ensureArg" "$ensureVal" )
 }
 
+# required by mongodb 4.2
 # _mongod_hack_rename_arg_save_val '--arg-to-rename' '--arg-to-rename-to' "$@"
 # set -- "${mongodHackedArgs[@]}"
 _mongod_hack_rename_arg_save_val() {
@@ -160,6 +161,7 @@ _mongod_hack_rename_arg_save_val() {
 	mongodHackedArgs+=("$newArg" "$val")
 }
 
+# required by mongodb 4.2
 # _mongod_hack_rename_arg'--arg-to-rename' '--arg-to-rename-to' "$@"
 # set -- "${mongodHackedArgs[@]}"
 _mongod_hack_rename_arg() {
@@ -393,47 +395,47 @@ if [ "$originalArgOne" = 'mongod' ]; then
 
 	MONGODB_VERSION=$(mongod --version  | head -1 | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
 
-  if [ '$MONGODB_VERSION' == "v4.2" ]; then
-    _mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
+	if [ '$MONGODB_VERSION' == "v4.2" ]; then
+		_mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
 
-    if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-      tlsMode="none"
-      if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
-        tlsMode='allowTLS'
-      elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
-        tlsMode='preferTLS'
-      elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
-        tlsMode='requireTLS'
-      fi
+		if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+		tlsMode="none"
+		if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
+			tlsMode='allowTLS'
+		elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
+			tlsMode='preferTLS'
+		elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
+			tlsMode='requireTLS'
+		fi
 
-      if [ "$tlsMode" != "none" ]; then
-        _mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
-        _mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
-      fi
-    fi
+		if [ "$tlsMode" != "none" ]; then
+			_mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
+			_mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
+		fi
+		fi
 
-    _mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
-    if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-      if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
-        _mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
-      fi
-    fi
-    _mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
+		if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+		if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
+			_mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
+		fi
+		fi
+		_mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
 
 
-    _mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
-  fi
+		_mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
+	fi
 
 	set -- "${mongodHackedArgs[@]}"
 

--- a/percona-server-mongodb.42/ps-entry.sh
+++ b/percona-server-mongodb.42/ps-entry.sh
@@ -396,46 +396,46 @@ if [ "$originalArgOne" = 'mongod' ]; then
 	MONGODB_VERSION=$(mongod --version  | head -1 | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
 
 	if [ '$MONGODB_VERSION' == "v4.2" ]; then
-	    _mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
 
-            if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-	        tlsMode="none"
-	        if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
-	            tlsMode='allowTLS'
-	        elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
-	            tlsMode='preferTLS'
-                elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
-	            tlsMode='requireTLS'
-	        fi
+		if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+			tlsMode="none"
+			if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
+				tlsMode='allowTLS'
+			elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
+				tlsMode='preferTLS'
+			elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
+				tlsMode='requireTLS'
+			fi
           
-	        if [ "$tlsMode" != "none" ]; then
-	            _mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
-		    _mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
+			if [ "$tlsMode" != "none" ]; then
+				_mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
+				_mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
+			fi
 		fi
-            fi
 
-	    _mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
-	    if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-	        if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
-	            _mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
-                fi
-            fi
-	    _mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
+		if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+			if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
+				_mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
+			fi
+		fi
+		_mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
 
 
-	    _mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
-	    _mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
-        fi
+		_mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
+	fi
 
 	set -- "${mongodHackedArgs[@]}"
 

--- a/percona-server-mongodb.42/ps-entry.sh
+++ b/percona-server-mongodb.42/ps-entry.sh
@@ -395,47 +395,47 @@ if [ "$originalArgOne" = 'mongod' ]; then
 
 	MONGODB_VERSION=$(mongod --version  | head -1 | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
 
-	if [ $MONGODB_VERSION == "v4.2" ]; then
-		_mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
+	if [ '$MONGODB_VERSION' == "v4.2" ]; then
+	    _mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
 
-		if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-		tlsMode="none"
-		if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
-			tlsMode='allowTLS'
-		elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
-			tlsMode='preferTLS'
-		elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
-			tlsMode='requireTLS'
+            if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+	        tlsMode="none"
+	        if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
+	            tlsMode='allowTLS'
+	        elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
+	            tlsMode='preferTLS'
+                elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
+	            tlsMode='requireTLS'
+	        fi
+          
+	        if [ "$tlsMode" != "none" ]; then
+	            _mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
+		    _mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
 		fi
+            fi
 
-		if [ "$tlsMode" != "none" ]; then
-			_mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
-			_mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
-		fi
-		fi
-
-		_mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
-		if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-		if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
-			_mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
-		fi
-		fi
-		_mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
+	    if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+	        if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
+	            _mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
+                fi
+            fi
+	    _mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
 
 
-		_mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
-		_mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
-	fi
+	    _mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
+	    _mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
+        fi
 
 	set -- "${mongodHackedArgs[@]}"
 

--- a/percona-server-mongodb.42/ps-entry.sh
+++ b/percona-server-mongodb.42/ps-entry.sh
@@ -136,6 +136,7 @@ _mongod_hack_ensure_arg_val() {
 	mongodHackedArgs+=( "$ensureArg" "$ensureVal" )
 }
 
+# required by mongodb 4.2
 # _mongod_hack_rename_arg_save_val '--arg-to-rename' '--arg-to-rename-to' "$@"
 # set -- "${mongodHackedArgs[@]}"
 _mongod_hack_rename_arg_save_val() {
@@ -160,6 +161,7 @@ _mongod_hack_rename_arg_save_val() {
 	mongodHackedArgs+=("$newArg" "$val")
 }
 
+# required by mongodb 4.2
 # _mongod_hack_rename_arg'--arg-to-rename' '--arg-to-rename-to' "$@"
 # set -- "${mongodHackedArgs[@]}"
 _mongod_hack_rename_arg() {
@@ -393,47 +395,47 @@ if [ "$originalArgOne" = 'mongod' ]; then
 
 	MONGODB_VERSION=$(mongod --version  | head -1 | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
 
-  if [ $MONGODB_VERSION == "v4.2" ]; then
-    _mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
+	if [ $MONGODB_VERSION == "v4.2" ]; then
+		_mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
 
-    if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-      tlsMode="none"
-      if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
-        tlsMode='allowTLS'
-      elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
-        tlsMode='preferTLS'
-      elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
-        tlsMode='requireTLS'
-      fi
+		if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+		tlsMode="none"
+		if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
+			tlsMode='allowTLS'
+		elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
+			tlsMode='preferTLS'
+		elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
+			tlsMode='requireTLS'
+		fi
 
-      if [ "$tlsMode" != "none" ]; then
-        _mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
-        _mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
-      fi
-    fi
+		if [ "$tlsMode" != "none" ]; then
+			_mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
+			_mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
+		fi
+		fi
 
-    _mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
-    if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-      if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
-        _mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
-      fi
-    fi
-    _mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
+		if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+		if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
+			_mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
+		fi
+		fi
+		_mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
 
 
-    _mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
-    _mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
-  fi
+		_mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
+		_mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
+	fi
 
 	set -- "${mongodHackedArgs[@]}"
 

--- a/percona-server-mongodb.42/ps-entry.sh
+++ b/percona-server-mongodb.42/ps-entry.sh
@@ -391,45 +391,49 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		fi
 	fi
 
-	_mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
+	MONGODB_VERSION=$(mongod --version  | head -1 | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
 
-	if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-		tlsMode="none"
-		if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
-			tlsMode='allowTLS'
-		elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
-			tlsMode='preferTLS'
-		elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
-			tlsMode='requireTLS'
-		fi
+  if [ $MONGODB_VERSION == "v4.2" ]; then
+    _mongod_hack_rename_arg_save_val --sslMode --tlsMode "${mongodHackedArgs[@]}"
 
-		if [ "$tlsMode" != "none" ]; then
-			_mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
-			_mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
-		fi
-	fi
+    if _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+      tlsMode="none"
+      if _mongod_hack_have_arg 'allowSSL' "${mongodHackedArgs[@]}"; then
+        tlsMode='allowTLS'
+      elif _mongod_hack_have_arg 'preferSSL' "${mongodHackedArgs[@]}"; then
+        tlsMode='preferTLS'
+      elif _mongod_hack_have_arg 'requireSSL' "${mongodHackedArgs[@]}"; then
+        tlsMode='requireTLS'
+      fi
 
-	_mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
-	if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
-		if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
-			_mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
-		fi
-	fi
-	_mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
-	_mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
-	_mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
-	_mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
+      if [ "$tlsMode" != "none" ]; then
+        _mongod_hack_ensure_no_arg_val --tlsMode "${mongodHackedArgs[@]}"
+        _mongod_hack_ensure_arg_val --tlsMode "$tlsMode" "${mongodHackedArgs[@]}"
+      fi
+    fi
+
+    _mongod_hack_rename_arg_save_val --sslPEMKeyFile --tlsCertificateKeyFile "${mongodHackedArgs[@]}"
+    if ! _mongod_hack_have_arg '--tlsMode' "${mongodHackedArgs[@]}"; then
+      if _mongod_hack_have_arg '--tlsCertificateKeyFile' "${mongodHackedArgs[@]}"; then
+        _mongod_hack_ensure_arg_val --tlsMode "preferTLS" "${mongodHackedArgs[@]}"
+      fi
+    fi
+    _mongod_hack_rename_arg '--sslAllowInvalidCertificates' '--tlsAllowInvalidCertificates' "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg '--sslAllowInvalidHostnames' '--tlsAllowInvalidHostnames' "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg '--sslAllowConnectionsWithoutCertificates' '--tlsAllowConnectionsWithoutCertificates' "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg '--sslFIPSMode' '--tlsFIPSMode' "${mongodHackedArgs[@]}"
 
 
-	_mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
-	_mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
-	_mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
-	_mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
-	_mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
-	_mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
-	_mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
-	_mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
-	_mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslPEMKeyPassword --tlsCertificateKeyFilePassword "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslClusterFile --tlsClusterFile "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslCertificateSelector --tlsCertificateSelector "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslClusterCertificateSelector --tlsClusterCertificateSelector "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslClusterPassword --tlsClusterPassword "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslCAFile --tlsCAFile "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslClusterCAFile --tlsClusterCAFile "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslCRLFile --tlsCRLFile "${mongodHackedArgs[@]}"
+    _mongod_hack_rename_arg_save_val --sslDisabledProtocols --tlsDisabledProtocols "${mongodHackedArgs[@]}"
+  fi
 
 	set -- "${mongodHackedArgs[@]}"
 


### PR DESCRIPTION
[![K8SPSMDB-207](https://badgen.net/badge/JIRA/K8SPSMDB-207/green)](https://jira.percona.com/browse/K8SPSMDB-207)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Make ps-enty is generic, which will work with different mongodb versios