### PR TITLE
K8SPXC-276 should have priority as writer in ProxySQL

### DIFF
--- a/proxysql/dockerdir/etc/proxysql-admin.cnf
+++ b/proxysql/dockerdir/etc/proxysql-admin.cnf
@@ -26,6 +26,7 @@ export OFFLINE_HOSTGROUP_ID='13'
 
 # ProxySQL read/write configuration mode.
 export MODE="singlewrite"
+export WRITE_NODE=""
 
 # max_connections default (used only when INSERTing a new mysql_servers entry)
 export MAX_CONNECTIONS="1000"

--- a/proxysql/dockerdir/usr/bin/add_pxc_nodes.sh
+++ b/proxysql/dockerdir/usr/bin/add_pxc_nodes.sh
@@ -54,6 +54,8 @@ function main() {
         SSL_ARG="--use-ssl=yes"
     fi
 
+    sed "s/WRITE_NODE=/WRITE_NODE='$first_host'/g" /etc/proxysql-admin.cnf 1<> /etc/proxysql-admin.cnf
+
     proxysql-admin \
         --config-file=/etc/proxysql-admin.cnf \
         --cluster-hostname="$first_host" \

--- a/proxysql/dockerdir/usr/bin/add_pxc_nodes.sh
+++ b/proxysql/dockerdir/usr/bin/add_pxc_nodes.sh
@@ -54,7 +54,7 @@ function main() {
         SSL_ARG="--use-ssl=yes"
     fi
 
-    sed "s/^WRITE_NODE=.*/WRITE_NODE='$first_host'/g" /etc/proxysql-admin.cnf 1<> /etc/proxysql-admin.cnf
+    sed "s/WRITE_NODE=.*/WRITE_NODE='$first_host'/g" /etc/proxysql-admin.cnf 1<> /etc/proxysql-admin.cnf
 
     proxysql-admin \
         --config-file=/etc/proxysql-admin.cnf \

--- a/proxysql/dockerdir/usr/bin/add_pxc_nodes.sh
+++ b/proxysql/dockerdir/usr/bin/add_pxc_nodes.sh
@@ -54,7 +54,7 @@ function main() {
         SSL_ARG="--use-ssl=yes"
     fi
 
-    sed "s/WRITE_NODE=.*/WRITE_NODE='$first_host'/g" /etc/proxysql-admin.cnf 1<> /etc/proxysql-admin.cnf
+    sed "s/WRITE_NODE=.*/WRITE_NODE='$first_host:3306'/g" /etc/proxysql-admin.cnf 1<> /etc/proxysql-admin.cnf
 
     proxysql-admin \
         --config-file=/etc/proxysql-admin.cnf \

--- a/proxysql/dockerdir/usr/bin/add_pxc_nodes.sh
+++ b/proxysql/dockerdir/usr/bin/add_pxc_nodes.sh
@@ -54,7 +54,7 @@ function main() {
         SSL_ARG="--use-ssl=yes"
     fi
 
-    sed "s/WRITE_NODE=/WRITE_NODE='$first_host'/g" /etc/proxysql-admin.cnf 1<> /etc/proxysql-admin.cnf
+    sed "s/^WRITE_NODE=.*/WRITE_NODE='$first_host'/g" /etc/proxysql-admin.cnf 1<> /etc/proxysql-admin.cnf
 
     proxysql-admin \
         --config-file=/etc/proxysql-admin.cnf \


### PR DESCRIPTION
[![K8SPXC-276](https://badgen.net/badge/JIRA/K8SPXC-276/green)](https://jira.percona.com/browse/K8SPXC-276)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

how to test:
```
kubectl exec -it cluster1-proxysql-0 -- \
    mysql -uproxyadmin -padmin_password -h127.0.0.1 -P 6032 \
    -e "SELECT hostgroup_id,hostname,status FROM mysql_servers WHERE hostgroup_id=11;"
```