### PR TITLE
K8SPXC-311 Add perl as required for pxb

### DIFF
--- a/pxc-80/Dockerfile
+++ b/pxc-80/Dockerfile
@@ -56,6 +56,7 @@ RUN yum update -y \
 		which \
 		pam \
 		gdb \
+		perl \
 	&& yum clean all
 
 # create mysql user/group before mysql installation

--- a/pxc-80/Dockerfile.k8s
+++ b/pxc-80/Dockerfile.k8s
@@ -59,6 +59,7 @@ RUN microdnf update -y \
 		pam \
 		gdb \
 		tar \
+		perl \
 	&& microdnf clean all
 
 # create mysql user/group before mysql installation


### PR DESCRIPTION
[![K8SPXC-311](https://badgen.net/badge/JIRA/K8SPXC-311/green)](https://jira.percona.com/browse/K8SPXC-311)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

New version of pxc could execute pxb under sst
which requires perl package