### PR TITLE
K8SPXC-344 writer always should point to pod-0

### DIFF
--- a/proxysql/dockerdir/usr/bin/add_pxc_nodes.sh
+++ b/proxysql/dockerdir/usr/bin/add_pxc_nodes.sh
@@ -43,6 +43,7 @@ function main() {
         echo "Could not find PEERS ..."
         exit
     fi
+    pod_zero=$(echo "$first_host" | cut -d . -f 1 | sed -r 's/-[0-9]+$/-0/')
     service=$(echo "$first_host" | cut -d . -f 2-)
 
     sleep 15s # wait for evs.inactive_timeout
@@ -54,7 +55,7 @@ function main() {
         SSL_ARG="--use-ssl=yes"
     fi
 
-    sed "s/WRITE_NODE=.*/WRITE_NODE='$first_host:3306'/g" /etc/proxysql-admin.cnf 1<> /etc/proxysql-admin.cnf
+    sed "s/WRITE_NODE=.*/WRITE_NODE='$pod_zero.$service:3306'/g" /etc/proxysql-admin.cnf 1<> /etc/proxysql-admin.cnf
 
     proxysql-admin \
         --config-file=/etc/proxysql-admin.cnf \


### PR DESCRIPTION
[![K8SPXC-344](https://badgen.net/badge/JIRA/K8SPXC-344/green)](https://jira.percona.com/browse/K8SPXC-344)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When Pod-0 is down, ProxySQL move traffic to the latest pod (Pod-2).
But, sometimes, Pod-0 (during fail) is not listed in the PXC service members.
Because of that, Pod-1 become the Writer for the proxysql-admin config.
in result we have many traffic switches, Pod-0 -> Pod-2, Pod-2 > Pod-1,
Pod-1 -> Pod-0.