### PR TITLE
K8SPXC-347 adjust the minimal size for md5 file

### DIFF
--- a/pxc-57-backup/backup.sh
+++ b/pxc-57-backup/backup.sh
@@ -144,7 +144,7 @@ function backup_s3() {
 
     mc -C /tmp/mc stat "dest/$S3_BUCKET/$S3_BUCKET_PATH.md5"
     md5_size=$(mc -C /tmp/mc stat --json "dest/$S3_BUCKET/$S3_BUCKET_PATH.md5" | sed -e 's/.*"size":\([0-9]*\).*/\1/')
-    if [[ $md5_size =~ "Object does not exist" ]] || (( $md5_size < 24000 )); then
+    if [[ $md5_size =~ "Object does not exist" ]] || (( $md5_size < 23000 )); then
         echo empty backup
         exit 1
     fi

--- a/pxc-80-backup/run_backup.sh
+++ b/pxc-80-backup/run_backup.sh
@@ -132,7 +132,7 @@ function backup_s3() {
 
     mc -C /tmp/mc stat "dest/$S3_BUCKET/$S3_BUCKET_PATH.md5"
     md5_size=$(mc -C /tmp/mc stat --json "dest/$S3_BUCKET/$S3_BUCKET_PATH.md5" | sed -e 's/.*"size":\([0-9]*\).*/\1/')
-    if [[ $md5_size =~ "Object does not exist" ]] || (($md5_size < 24000)); then
+    if [[ $md5_size =~ "Object does not exist" ]] || (($md5_size < 23000)); then
         echo empty backup
          exit 1
     fi


### PR DESCRIPTION
[![K8SPXC-347](https://badgen.net/badge/JIRA/K8SPXC-347/green)](https://jira.percona.com/browse/K8SPXC-347)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

in some cases final md5 file size is less than 24kb.
according to reported issue by in K8SPXC-347, 23kb should be enoght.