### PR TITLE
K8SPXC-366 Delete old backups before garbd is run

### DIFF
--- a/pxc-80-backup/backup.sh
+++ b/pxc-80-backup/backup.sh
@@ -50,6 +50,13 @@ function request_streaming() {
         exit 1
     fi
 
+    if [ -n "$S3_BUCKET" ]; then
+        SST_INFO_NAME=sst_info
+        S3_BUCKET_PATH=${S3_BUCKET_PATH:-$PXC_SERVICE-$(date +%F-%H-%M)-xtrabackup.stream}
+        xbcloud delete --storage=s3 --s3-bucket="$S3_BUCKET" "$S3_BUCKET_PATH.$SST_INFO_NAME" || :
+        xbcloud delete --storage=s3 --s3-bucket="$S3_BUCKET" "$S3_BUCKET_PATH" || :
+    fi
+
     echo '[INFO] garbd was started'
         garbd \
             --address "gcomm://$NODE_NAME.$PXC_SERVICE?gmcast.listen_addr=tcp://0.0.0.0:4567" \

--- a/pxc-80-backup/run_backup.sh
+++ b/pxc-80-backup/run_backup.sh
@@ -107,9 +107,6 @@ function backup_s3() {
     mc -C /tmp/mc config host add dest "${ENDPOINT:-https://s3.amazonaws.com}" "$ACCESS_KEY_ID" "$SECRET_ACCESS_KEY"
     set -x
 
-    xbcloud delete --storage=s3 --s3-bucket="$S3_BUCKET" "$S3_BUCKET_PATH.$SST_INFO_NAME" || :
-    xbcloud delete --storage=s3 --s3-bucket="$S3_BUCKET" "$S3_BUCKET_PATH" || :
-
     socat -u "$SOCAT_OPTS" stdio | xbstream -x -C /tmp &
     wait $!
     echo "Socat was started"


### PR DESCRIPTION
[![K8SPXC-366](https://badgen.net/badge/JIRA/K8SPXC-366/green)](https://jira.percona.com/browse/K8SPXC-366)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* if we delete old 'full' backups via garbd it causes the situation
       that garbd sometimes terminates it and backups can not be
       deleted.