### PR TITLE
Remove --decompress option for xbstream in PXC 5.7 backup images

### DIFF
--- a/pxc-57-backup/recovery-pvc-joiner.sh
+++ b/pxc-57-backup/recovery-pvc-joiner.sh
@@ -40,7 +40,7 @@ rm -rf /datadir/*
 tmp=$(mktemp --directory /datadir/pxc_sst_XXXX)
 
 socat -u "$SOCAT_OPTS" stdio >$tmp/sst_info
-socat -u "$SOCAT_OPTS" stdio | xbstream --decompress -x -C $tmp --parallel=$(grep -c processor /proc/cpuinfo)
+socat -u "$SOCAT_OPTS" stdio | xbstream -x -C $tmp --parallel=$(grep -c processor /proc/cpuinfo)
 
 set +o xtrace
 transition_key=$(vault_get $tmp/sst_info)

--- a/pxc-57-backup/recovery-s3.sh
+++ b/pxc-57-backup/recovery-s3.sh
@@ -16,7 +16,7 @@ mc -C /tmp/mc ls "dest/${S3_BUCKET_URL}"
 rm -rf /datadir/*
 tmp=$(mktemp --directory /datadir/pxc_sst_XXXX)
 xbcloud get "s3://${S3_BUCKET_URL}.sst_info" --parallel=10 | xbstream -x -C $tmp --parallel=$(grep -c processor /proc/cpuinfo)
-xbcloud get "s3://${S3_BUCKET_URL}" --parallel=10 | xbstream --decompress -x -C $tmp --parallel=$(grep -c processor /proc/cpuinfo)
+xbcloud get "s3://${S3_BUCKET_URL}" --parallel=10 | xbstream -x -C $tmp --parallel=$(grep -c processor /proc/cpuinfo)
 
 set +o xtrace
 transition_key=$(vault_get $tmp/sst_info)


### PR DESCRIPTION
PXB 2.4 doesn't support lz4 compression so xbstream doesn't have `--decompress` option.
Some tests on 5.7 were failing like this:
```
$ k logs restore-job-on-demand-backup-pvc-one-pod-zsv9x
+ LIB_PATH=/usr/lib/pxc
+ . /usr/lib/pxc/check-version.sh
+ . /usr/lib/pxc/vault.sh
++ set -o errexit
++ keyring_vault=/etc/mysql/vault-keyring-secret/keyring_vault.conf
+ SOCAT_OPTS=TCP:restore-src-on-demand-backup-pvc-one-pod:3307,retry=30
+ check_ssl
+ CA=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+ '[' -f /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt ']'
+ SSL_DIR=/etc/mysql/ssl
+ '[' -f /etc/mysql/ssl/ca.crt ']'
+ SSL_INTERNAL_DIR=/etc/mysql/ssl-internal
+ '[' -f /etc/mysql/ssl-internal/ca.crt ']'
+ KEY=/etc/mysql/ssl/tls.key
+ CERT=/etc/mysql/ssl/tls.crt
+ '[' -f /etc/mysql/ssl-internal/tls.key -a -f /etc/mysql/ssl-internal/tls.crt ']'
+ '[' -f /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -a -f /etc/mysql/ssl/tls.key -a -f /etc/mysql/ssl/tls.crt ']'
+ ping -c1 restore-src-on-demand-backup-pvc-one-pod
PING restore-src-on-demand-backup-pvc-one-pod.one-pod-18340.svc.cluster.local (10.51.252.171) 56(84) bytes of data.

--- restore-src-on-demand-backup-pvc-one-pod.one-pod-18340.svc.cluster.local ping statistics ---
1 packets transmitted, 0 received, 100% packet loss, time 0ms

+ :
+ rm -rf /datadir/auto.cnf /datadir/binlog.000001 /datadir/binlog.000002 /datadir/binlog.000003 /datadir/binlog.000004 /datadir/binlog.index /datadir/ca-key.pem /datadir/ca.pem /datadir/client-cert.pem /datadir/c
lient-key.pem /datadir/galera.cache /datadir/grastate.dat /datadir/ib_buffer_pool /datadir/ib_logfile0 /datadir/ib_logfile1 /datadir/ibdata1 /datadir/innobackup.backup.log /datadir/myApp /datadir/mysql /datadir/p
erformance_schema /datadir/private_key.pem /datadir/public_key.pem /datadir/server-cert.pem /datadir/server-key.pem /datadir/sst_in_progress /datadir/sys /datadir/version_info
++ mktemp --tmpdir --directory pxc_sst_XXXX
+ tmp=/tmp/pxc_sst_o7v2
+ socat -u TCP:restore-src-on-demand-backup-pvc-one-pod:3307,retry=30 stdio
+ socat -u TCP:restore-src-on-demand-backup-pvc-one-pod:3307,retry=30 stdio
++ grep -c processor /proc/cpuinfo
+ xbstream --decompress -x -C /tmp/pxc_sst_o7v2 --parallel=4
xbstream: [ERROR] unknown option '--decompress'
2020/07/17 06:37:36 socat[10] E write(1, 0x55bc0a5fd630, 8192): Broken pipe
```