### PR TITLE
K8SPXC-464 add usage of 'pc.weight' option

### DIFF
--- a/percona-xtradb-cluster-5.7-backup/backup.sh
+++ b/percona-xtradb-cluster-5.7-backup/backup.sh
@@ -41,7 +41,7 @@ function check_ssl() {
     fi
 
     if [ -f "$CA" -a -f "$KEY" -a -f "$CERT" ]; then
-        GARBD_OPTS="socket.ssl_ca=${CA};socket.ssl_cert=${CERT};socket.ssl_key=${KEY};socket.ssl_cipher=;${GARBD_OPTS}"
+        GARBD_OPTS="socket.ssl_ca=${CA};socket.ssl_cert=${CERT};socket.ssl_key=${KEY};socket.ssl_cipher=;pc.weight=1;${GARBD_OPTS}"
         SOCAT_OPTS="openssl-listen:4444,reuseaddr,cert=${CERT},key=${KEY},cafile=${CA},verify=1,retry=30"
     fi
 }

--- a/percona-xtradb-cluster-8.0-backup/backup.sh
+++ b/percona-xtradb-cluster-8.0-backup/backup.sh
@@ -36,7 +36,7 @@ function check_ssl() {
     fi
 
     if [ -f "$CA" -a -f "$KEY" -a -f "$CERT" ]; then
-        GARBD_OPTS="socket.ssl_ca=${CA};socket.ssl_cert=${CERT};socket.ssl_key=${KEY};socket.ssl_cipher=;${GARBD_OPTS}"
+        GARBD_OPTS="socket.ssl_ca=${CA};socket.ssl_cert=${CERT};socket.ssl_key=${KEY};socket.ssl_cipher=;pc.weight=1;${GARBD_OPTS}"
     fi
 }
 


### PR DESCRIPTION
[![K8SPXC-464](https://badgen.net/badge/JIRA/K8SPXC-464/green)](https://jira.percona.com/browse/K8SPXC-464)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* add usage of 'pc.weight' option to avoid situation
      when pxc node becomes non-primary when backup via garbd
      fails for one pod installation