### PR TITLE
Revert "K8SPXC-438 add possibility to use 32 symbols for cluster name"

### DIFF
--- a/percona-xtradb-cluster-5.7-backup/backup.sh
+++ b/percona-xtradb-cluster-5.7-backup/backup.sh
@@ -60,7 +60,7 @@ function request_streaming() {
         garbd \
             --address "gcomm://$NODE_NAME.$PXC_SERVICE?gmcast.listen_addr=tcp://0.0.0.0:4567" \
             --donor "$NODE_NAME" \
-            --group "${PXC_SERVICE%'-pxc'}" \
+            --group "$PXC_SERVICE" \
             --options "$GARBD_OPTS" \
             --sst "xtrabackup-v2:$LOCAL_IP:4444/xtrabackup_sst//1" \
             2>&1 | tee /tmp/garbd.log

--- a/percona-xtradb-cluster-8.0-backup/backup.sh
+++ b/percona-xtradb-cluster-8.0-backup/backup.sh
@@ -54,7 +54,7 @@ function request_streaming() {
         garbd \
             --address "gcomm://$NODE_NAME.$PXC_SERVICE?gmcast.listen_addr=tcp://0.0.0.0:4567" \
             --donor "$NODE_NAME" \
-            --group "${PXC_SERVICE%'-pxc'}" \
+            --group "$PXC_SERVICE" \
             --options "$GARBD_OPTS" \
             --sst "xtrabackup-v2:$LOCAL_IP:4444/xtrabackup_sst//1" \
             --recv-script="/usr/bin/run_backup.sh"


### PR DESCRIPTION
[![K8SPXC-370](https://badgen.net/badge/JIRA/K8SPXC-370/green)](https://jira.percona.com/browse/K8SPXC-370)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Reverts percona/percona-docker#310