### PR TITLE
K8SPXC-553 use 'yes' as a default value for 'WRITERS_ARE_READERS'

### DIFF
--- a/proxysql/dockerdir/entrypoint.sh
+++ b/proxysql/dockerdir/entrypoint.sh
@@ -8,6 +8,7 @@ PROXY_ADMIN_CFG=/etc/proxysql-admin.cnf
 if [ -n ${PROXYSQL_SERVICE} ]; then
     MYSQL_INTERFACES='0.0.0.0:3306;0.0.0.0:33062'
     CLUSTER_PORT='33062'
+    WRITERS_ARE_READERS='yes'
 fi
 
 sed "s/interfaces=\"0.0.0.0:3306\"/interfaces=\"${MYSQL_INTERFACES:-0.0.0.0:3306}\"/g" ${PROXY_CFG} 1<> ${PROXY_CFG}
@@ -30,6 +31,7 @@ sed "s/CLUSTER_PASSWORD='admin'/CLUSTER_PASSWORD='${OPERATOR_PASSWORD_ESCAPED:-o
 sed "s/CLUSTER_PORT='3306'/CLUSTER_PORT='${CLUSTER_PORT:-3306}'/g"       ${PROXY_ADMIN_CFG} 1<> ${PROXY_ADMIN_CFG}
 sed "s/MONITOR_USERNAME='monitor'/MONITOR_USERNAME='monitor'/g"                          ${PROXY_ADMIN_CFG} 1<> ${PROXY_ADMIN_CFG}
 sed "s/MONITOR_PASSWORD='monitor'/MONITOR_PASSWORD='${MONITOR_PASSWORD_ESCAPED:-monitor}'/g"     ${PROXY_ADMIN_CFG} 1<> ${PROXY_ADMIN_CFG}
+sed "s/WRITERS_ARE_READERS='backup'/WRITERS_ARE_READERS='${WRITERS_ARE_READERS:-backup}'/g"     ${PROXY_ADMIN_CFG} 1<> ${PROXY_ADMIN_CFG}
 set -o xtrace
 
 ## SSL/TLS support

--- a/proxysql/dockerdir/etc/proxysql-admin.cnf
+++ b/proxysql/dockerdir/etc/proxysql-admin.cnf
@@ -27,6 +27,7 @@ export OFFLINE_HOSTGROUP_ID='13'
 # ProxySQL read/write configuration mode.
 export MODE="singlewrite"
 export WRITE_NODE=""
+export WRITERS_ARE_READERS='backup'
 
 # max_connections default (used only when INSERTing a new mysql_servers entry)
 export MAX_CONNECTIONS="1000"


### PR DESCRIPTION
[![K8SPXC-553](https://badgen.net/badge/JIRA/K8SPXC-553/green)](https://jira.percona.com/browse/K8SPXC-553)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* for PXCO we need to use 'yes' (by default it is 'backup')
      as a defult value for 'WRITERS_ARE_READERS' option to add
      all writers to read hostgroup