### PR TITLE
Fix PS version in PXC 5.7 backup image

### DIFF
--- a/percona-xtradb-cluster-5.7-backup/Dockerfile
+++ b/percona-xtradb-cluster-5.7-backup/Dockerfile
@@ -33,7 +33,7 @@ helps enterprises avoid downtime and outages and meet expected customer experien
 LABEL org.opencontainers.image.license="GPL"
 
 ENV PXB_VERSION 2.4.21-1
-ENV PS_VERSION 5.7.31-34.1
+ENV PS_VERSION 5.7.32-35.1
 ENV PXC_VERSION 5.7.32-31.47.1
 ENV KUBECTL_VERSION=v1.15.6
 ENV KUBECTL_SHA256SUM=522115e0f11d83c08435a05e76120c89ea320782ccaff8e301bd14588ec50145


### PR DESCRIPTION
PS_VERSION most probably should be the same as PXC_VERSION because it selects shared/shared-compat packages which will be installed.