### PR TITLE
Remove binlog-info for PXC 8.0 backup since PXB 8.0 doesn't have it

### DIFF
--- a/percona-xtradb-cluster-8.0-backup/recovery-pvc-joiner.sh
+++ b/percona-xtradb-cluster-8.0-backup/recovery-pvc-joiner.sh
@@ -56,18 +56,18 @@ if [[ -n $transition_key && $transition_key != null ]]; then
     echo transition-key exists
 fi
 
-echo "+ xtrabackup ${XB_USE_MEMORY+--use-memory=$XB_USE_MEMORY} --prepare --binlog-info=ON --rollback-prepared-trx \
+echo "+ xtrabackup ${XB_USE_MEMORY+--use-memory=$XB_USE_MEMORY} --prepare --rollback-prepared-trx \
     --xtrabackup-plugin-dir=/usr/lib64/xtrabackup/plugin --target-dir=$tmp"
 
-xtrabackup ${XB_USE_MEMORY+--use-memory=$XB_USE_MEMORY} --prepare --binlog-info=ON $transition_option --rollback-prepared-trx \
+xtrabackup ${XB_USE_MEMORY+--use-memory=$XB_USE_MEMORY} --prepare $transition_option --rollback-prepared-trx \
     --xtrabackup-plugin-dir=/usr/lib64/xtrabackup/plugin --target-dir=$tmp
 
-echo "+ xtrabackup --defaults-group=mysqld --datadir=/datadir --move-back --binlog-info=ON \
+echo "+ xtrabackup --defaults-group=mysqld --datadir=/datadir --move-back \
     --force-non-empty-directories $master_key_options \
     --keyring-vault-config=/etc/mysql/vault-keyring-secret/keyring_vault.conf --early-plugin-load=keyring_vault.so \
     --xtrabackup-plugin-dir=/usr/lib64/xtrabackup/plugin --target-dir=$tmp"
 
-xtrabackup --defaults-group=mysqld --datadir=/datadir --move-back --binlog-info=ON \
+xtrabackup --defaults-group=mysqld --datadir=/datadir --move-back \
     --force-non-empty-directories $transition_option $master_key_options \
     --keyring-vault-config=/etc/mysql/vault-keyring-secret/keyring_vault.conf --early-plugin-load=keyring_vault.so \
     --xtrabackup-plugin-dir=/usr/lib64/xtrabackup/plugin --target-dir=$tmp

--- a/percona-xtradb-cluster-8.0-backup/recovery-s3.sh
+++ b/percona-xtradb-cluster-8.0-backup/recovery-s3.sh
@@ -32,18 +32,18 @@ if [[ -n $transition_key && $transition_key != null ]]; then
     echo transition-key exists
 fi
 
-echo "+ xtrabackup ${XB_USE_MEMORY+--use-memory=$XB_USE_MEMORY} --prepare --binlog-info=ON --rollback-prepared-trx \
+echo "+ xtrabackup ${XB_USE_MEMORY+--use-memory=$XB_USE_MEMORY} --prepare --rollback-prepared-trx \
     --xtrabackup-plugin-dir=/usr/lib64/xtrabackup/plugin --target-dir=$tmp"
 
-xtrabackup ${XB_USE_MEMORY+--use-memory=$XB_USE_MEMORY} --prepare --binlog-info=ON $transition_option --rollback-prepared-trx \
+xtrabackup ${XB_USE_MEMORY+--use-memory=$XB_USE_MEMORY} --prepare $transition_option --rollback-prepared-trx \
     --xtrabackup-plugin-dir=/usr/lib64/xtrabackup/plugin --target-dir=$tmp
 
-echo "+ xtrabackup --defaults-group=mysqld --datadir=/datadir --move-back --binlog-info=ON \
+echo "+ xtrabackup --defaults-group=mysqld --datadir=/datadir --move-back \
     --force-non-empty-directories $master_key_options \
     --keyring-vault-config=/etc/mysql/vault-keyring-secret/keyring_vault.conf --early-plugin-load=keyring_vault.so \
     --xtrabackup-plugin-dir=/usr/lib64/xtrabackup/plugin --target-dir=$tmp"
 
-xtrabackup --defaults-group=mysqld --datadir=/datadir --move-back --binlog-info=ON \
+xtrabackup --defaults-group=mysqld --datadir=/datadir --move-back \
     --force-non-empty-directories $transition_option $master_key_options \
     --keyring-vault-config=/etc/mysql/vault-keyring-secret/keyring_vault.conf --early-plugin-load=keyring_vault.so \
     --xtrabackup-plugin-dir=/usr/lib64/xtrabackup/plugin --target-dir=$tmp


### PR DESCRIPTION
Seems that PXB 8.0 doesn't have `binlog-info` option and is throwing warning like below.
I'm not going to rebuild backup images for this since just a warning, but it might be good to cleanup this.
```
+ xtrabackup  --prepare --binlog-info=ON --rollback-prepared-trx     --xtrabackup-plugin-dir=/usr/lib64/xtrabackup/plugin --target-dir=/datadir/pxc_sst_nybk
xtrabackup: recognized server arguments: --innodb_checksum_algorithm=crc32 --innodb_log_checksums=1 --innodb_data_file_path=ibdata1:12M:autoextend --innodb_log_files_in_group=2 --innodb_log_file_size=50331648 --innodb_page_size=16384 --innodb_undo_directory=./ --innodb_undo_tablespaces=2 --server-id=10 --innodb_log_checksums=ON --innodb_redo_log_encrypt=0 --innodb_undo_log_encrypt=0
xtrabackup: recognized client arguments: --prepare=1 --rollback-prepared-trx=1 --xtrabackup-plugin-dir=/usr/lib64/xtrabackup/plugin --target-dir=/datadir/pxc_sst_nybk
xtrabackup version 8.0.22-15 based on MySQL server 8.0.22 Linux (x86_64) (revision id: fea8a0e)
xtrabackup: cd to /datadir/pxc_sst_nybk/
xtrabackup: This target seems to be not prepared yet.                                                                                                                                                               Number of pools: 1
xtrabackup: xtrabackup_logfile detected: size=8388608, start_lsn=(28190126)
xtrabackup: using the following InnoDB configuration for recovery:
xtrabackup:   innodb_data_home_dir = .
xtrabackup:   innodb_data_file_path = ibdata1:12M:autoextend
xtrabackup:   innodb_log_group_home_dir = .
xtrabackup:   innodb_log_files_in_group = 1
xtrabackup:   innodb_log_file_size = 8388608
WARNING: unknown option --binlog-info=ON
xtrabackup: using the following InnoDB configuration for recovery:
xtrabackup:   innodb_data_home_dir = .
xtrabackup:   innodb_data_file_path = ibdata1:12M:autoextend
xtrabackup:   innodb_log_group_home_dir = .
xtrabackup:   innodb_log_files_in_group = 1
xtrabackup:   innodb_log_file_size = 8388608
xtrabackup: Starting InnoDB instance for recovery.
xtrabackup: Using 104857600 bytes for buffer pool (set by --use-memory parameter)
```