### PR TITLE
Fixed K8SPXC-616 (debug script not working)

### DIFF
--- a/percona-xtradb-cluster-8.0/dockerdir/usr/local/bin/mysqld-debug
+++ b/percona-xtradb-cluster-8.0/dockerdir/usr/local/bin/mysqld-debug
@@ -3,8 +3,8 @@
 set -o xtrace
 
 touch /tmp/recovery-case
-if [[ "$@" == *--skip-networking* ]]; then
+if [[ "$@" == *"--wsrep_start_position"* ]] || [[ "$@" == "" ]] ; then
+   /usr/sbin/mysqld-ps "$@" || sleep infinity
+else
     exec /usr/sbin/mysqld-ps "$@" 
 fi
-
-/usr/sbin/mysqld-ps "$@" || sleep infinity


### PR DESCRIPTION
[![K8SPXC-616](https://badgen.net/badge/JIRA/K8SPXC-616/green)](https://jira.percona.com/browse/K8SPXC-616) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPXC-616

Problem: Debug script is sleep while entrypoint.sh is checking for
config.

Fix: Adjusted debug script to only sleep when we are starting mysqld.