### PR TITLE
K8SPXC-430 use 'pc.weight=0' for garbd

### DIFF
--- a/percona-xtradb-cluster-5.7-backup/backup.sh
+++ b/percona-xtradb-cluster-5.7-backup/backup.sh
@@ -41,7 +41,7 @@ function check_ssl() {
     fi
 
     if [ -f "$CA" -a -f "$KEY" -a -f "$CERT" ]; then
-        GARBD_OPTS="socket.ssl_ca=${CA};socket.ssl_cert=${CERT};socket.ssl_key=${KEY};socket.ssl_cipher=;pc.weight=1;${GARBD_OPTS}"
+        GARBD_OPTS="socket.ssl_ca=${CA};socket.ssl_cert=${CERT};socket.ssl_key=${KEY};socket.ssl_cipher=;pc.weight=0;${GARBD_OPTS}"
         SOCAT_OPTS="openssl-listen:4444,reuseaddr,cert=${CERT},key=${KEY},cafile=${CA},verify=1,retry=30"
     fi
 }

--- a/percona-xtradb-cluster-8.0-backup/backup.sh
+++ b/percona-xtradb-cluster-8.0-backup/backup.sh
@@ -36,7 +36,7 @@ function check_ssl() {
     fi
 
     if [ -f "$CA" -a -f "$KEY" -a -f "$CERT" ]; then
-        GARBD_OPTS="socket.ssl_ca=${CA};socket.ssl_cert=${CERT};socket.ssl_key=${KEY};socket.ssl_cipher=;pc.weight=1;${GARBD_OPTS}"
+        GARBD_OPTS="socket.ssl_ca=${CA};socket.ssl_cert=${CERT};socket.ssl_key=${KEY};socket.ssl_cipher=;pc.weight=0;${GARBD_OPTS}"
     fi
 }
 


### PR DESCRIPTION
[![K8SPXC-430](https://badgen.net/badge/JIRA/K8SPXC-430/green)](https://jira.percona.com/browse/K8SPXC-430) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* use 'pc.weight=0' for garbd backup process in this case
      'garbd' will be allowed to take a backup without
      participation in the quorum calculations