### PR TITLE
Add insecure-fork-wanted option to haproxy

### DIFF
--- a/haproxy/dockerdir/etc/haproxy/haproxy-global.cfg
+++ b/haproxy/dockerdir/etc/haproxy/haproxy-global.cfg
@@ -1,6 +1,7 @@
     global
       maxconn 2048
       external-check
+      insecure-fork-wanted
       stats socket /etc/haproxy/pxc/haproxy.sock mode 600 expose-fd listeners level admin
 
     defaults


### PR DESCRIPTION
haproxy version was bumped from `2.1.x` to `2.3.2` which introduces some new options and hardening so some tests and probes were failing.
Some info: https://www.haproxy.com/blog/announcing-haproxy-2-2/#security-hardening
I have executed the `users` test locally with the custom image (`plavi/test:test-haproxy`) and it passed.

Error: 
```
│ [ALERT] 092/171857 (7) : Failed to fork process for external health check (likely caused by missing 'insecure-fork-wanted'): Resource temporarily unavailable. Aborting.                                         │
│ [ALERT] 092/171858 (7) : Failed to fork process for external health check (likely caused by missing 'insecure-fork-wanted'): Resource temporarily unavailable. Aborting.                                         │
│ [ALERT] 092/171859 (7) : Failed to fork process for external health check (likely caused by missing 'insecure-fork-wanted'): Resource temporarily unavailable. Aborting.                                         │
│ [ALERT] 092/171900 (7) : Failed to fork process for external health check (likely caused by missing 'insecure-fork-wanted'): Resource temporarily unavailable. Aborting.                                         │
│ [ALERT] 092/171902 (7) : Failed to fork process for external health check (likely caused by missing 'insecure-fork-wanted'): Resource temporarily unavailable. Aborting.                                         │
│ [ALERT] 092/171903 (7) : Failed to fork process for external health check (likely caused by missing 'insecure-fork-wanted'): Resource temporarily unavailable. Aborting.                                         │
│ [ALERT] 092/171904 (7) : Failed to fork process for external health check (likely caused by missing 'insecure-fork-wanted'): Resource temporarily unavailable. Aborting.                                         │
│ [WARNING] 092/171904 (1) : Exiting Master process...                                                                                                                                                             │
│ [WARNING] 092/171904 (7) : Proxy galera-in stopped (cumulated conns: FE: 36, BE: 0).                                                                                                                             │
│ [WARNING] 092/171904 (7) : Proxy galera-admin-in stopped (cumulated conns: FE: 0, BE: 0).                                                                                                                        │
│ [WARNING] 092/171904 (7) : Proxy galera-replica-in stopped (cumulated conns: FE: 0, BE: 0).                                                                                                                      │
│ [WARNING] 092/171904 (7) : Stopping frontend GLOBAL in 0 ms.                                                                                                                                                     │
│ [WARNING] 092/171904 (7) : Stopping backend galera-nodes in 0 ms.                                                                                                                                                │
│ [WARNING] 092/171904 (7) : Stopping backend galera-admin-nodes in 0 ms.                                                                                                                                          │
│ [WARNING] 092/171904 (7) : Stopping backend galera-replica-nodes in 0 ms.                                                                                                                                        │
│ [WARNING] 092/171904 (1) : All workers exited. Exiting... (0)

Events:
  Type     Reason     Age                    From               Message
  ----     ------     ----                   ----               -------
  Normal   Scheduled  23m                    default-scheduler  Successfully assigned users-32408/some-name-haproxy-0 to gke-tomislav-cluster-118-default-pool-18e90241-cb4b
  Normal   Pulling    23m                    kubelet            Pulling image "percona/percona-xtradb-cluster-operator:1.8.0-haproxy"
  Normal   Pulled     23m                    kubelet            Successfully pulled image "percona/percona-xtradb-cluster-operator:1.8.0-haproxy"
  Normal   Created    23m                    kubelet            Created container haproxy
  Normal   Started    23m                    kubelet            Started container haproxy
  Normal   Pulling    23m (x2 over 23m)      kubelet            Pulling image "percona/percona-xtradb-cluster-operator:1.8.0-haproxy"
  Normal   Pulled     23m (x2 over 23m)      kubelet            Successfully pulled image "percona/percona-xtradb-cluster-operator:1.8.0-haproxy"
  Normal   Created    23m (x2 over 23m)      kubelet            Created container pxc-monit
  Normal   Started    23m (x2 over 23m)      kubelet            Started container pxc-monit
  Warning  Unhealthy  22m                    kubelet            Liveness probe failed: ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 2
  Warning  Unhealthy  3m57s (x210 over 23m)  kubelet            Readiness probe failed: ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 2
```