### PR TITLE
entrypoint: Disable binlog while loading tzinfo

### DIFF
--- a/percona-server-8.0/ps-entry.sh
+++ b/percona-server-8.0/ps-entry.sh
@@ -132,8 +132,11 @@ if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
 		fi
 
 		if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
-			# sed is for https://bugs.mysql.com/bug.php?id=20545
-			mysql_tzinfo_to_sql /usr/share/zoneinfo | sed 's/Local time zone must be set--see zic manual page/FCTY/' | "${mysql[@]}" mysql
+			(
+				echo "SET @@SESSION.SQL_LOG_BIN = off;"
+				# sed is for https://bugs.mysql.com/bug.php?id=20545
+				mysql_tzinfo_to_sql /usr/share/zoneinfo | sed 's/Local time zone must be set--see zic manual page/FCTY/'
+			) | "${mysql[@]}" mysql
 		fi
 
 		# install TokuDB engine


### PR DESCRIPTION
When running mysqlsh clusterAddInstance to create a cluster the
following warnings are added to the output of mysqlsh

This change turns off SQL_BIN_LOG so that the GTID is not generated by
the initial tzinfo insert statements.

```
WARNING: A GTID set check of the MySQL instance at 'hostname.svc.cluster.local:3306' determined that it contains transactions that do not originate from the cluster, which must be discarded before it can join the cluster.
hostname.svc.cluster.local:3306 has the following errant GTIDs that do not exist in the cluster:
c8ee89a9-840a-11eb-8a25-0242ac11000b:1-5
```
We only made this change to the percona-server-8.0 entry point. Let us know to which other images this change should be added.

Co-authored-by: David Sharp <dsharp@vmware.com>
Co-authored-by: Colin Shield <cshield@vmware.com>