### PR TITLE
Fetch dependency js-yaml

### DIFF
--- a/percona-server-mongodb-4.4/Dockerfile
+++ b/percona-server-mongodb-4.4/Dockerfile
@@ -77,7 +77,8 @@ RUN set -ex; \
     chmod 0755 /usr/local/bin/k8s-mongodb-initiator /usr/local/bin/mongodb-healthcheck
 
 RUN set -ex; \
-    curl -fSL https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js -o /js-yaml.js
+    curl -fSL https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js -o /js-yaml.js; \
+    echo "45dc3dd03dc07a06705a2c2989b8c7f709013f04bd5386e3279d4e447f07ebd7  /js-yaml.js" | sha256sum -c -
 
 COPY ps-entry.sh /entrypoint.sh
 

--- a/percona-server-mongodb-4.4/Dockerfile
+++ b/percona-server-mongodb-4.4/Dockerfile
@@ -76,6 +76,9 @@ RUN set -ex; \
     \
     chmod 0755 /usr/local/bin/k8s-mongodb-initiator /usr/local/bin/mongodb-healthcheck
 
+RUN set -ex; \
+    curl -fSL https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js -o /js-yaml.js
+
 COPY ps-entry.sh /entrypoint.sh
 
 VOLUME ["/data/db"]


### PR DESCRIPTION
I got the error that there is no "/js-yaml.js" when supplying a mongod.conf as an argument. See entrypoint.sh line 192.
You should add jsyaml in some way. The proposed change is just one solution to supply that file, which might not be ideal.