### PR TITLE
K8SPXC-835: Fix pxc-monit crash on replica cluster

### DIFF
--- a/proxysql/Dockerfile.k8s
+++ b/proxysql/Dockerfile.k8s
@@ -76,7 +76,7 @@ RUN groupadd -g 1001 proxysql; \
 
 # we need licenses from docs
 RUN set -ex; \
-    curl -Lf -o /tmp/util-linux.rpm http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/util-linux-2.32.1-24.el8.x86_64.rpm; \
+    curl -Lf -o /tmp/util-linux.rpm http://mirror.centos.org/centos/8/BaseOS/x86_64/os/Packages/util-linux-2.32.1-27.el8.x86_64.rpm; \
     curl -Lf -o /tmp/proxysql2-${FULL_PROXYSQL_VERSION}.rpm http://repo.percona.com/percona/yum/release/8/RPMS/x86_64/proxysql2-${FULL_PROXYSQL_VERSION}.x86_64.rpm; \
     rpmkeys --checksig /tmp/proxysql2-${FULL_PROXYSQL_VERSION}.rpm /tmp/util-linux.rpm; \
     rpm -iv /tmp/proxysql2-${FULL_PROXYSQL_VERSION}.rpm /tmp/util-linux.rpm --nodeps; \

--- a/proxysql/dockerdir/usr/bin/add_pxc_nodes.sh
+++ b/proxysql/dockerdir/usr/bin/add_pxc_nodes.sh
@@ -55,7 +55,10 @@ function main() {
         SSL_ARG="--use-ssl=yes"
     fi
 
-    sed "s/WRITE_NODE=.*/WRITE_NODE='$pod_zero.$service:3306'/g" /etc/proxysql-admin.cnf 1<> /etc/proxysql-admin.cnf
+    # don't assign pod to WRITE_NODE if it's replica in cross-site replication
+    if [ "$(mysql_root_exec "$service" 'select @@read_only')" != "1" ]; then
+        sed "s/WRITE_NODE=.*/WRITE_NODE='$pod_zero.$service:3306'/g" /etc/proxysql-admin.cnf 1<> /etc/proxysql-admin.cnf
+    fi
 
     proxysql-admin \
         --config-file=/etc/proxysql-admin.cnf \


### PR DESCRIPTION
[![K8SPXC-835](https://badgen.net/badge/JIRA/K8SPXC-835/green)](https://jira.percona.com/browse/K8SPXC-835) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I needed to change RPM package URL for util-linux, since the old one returning 404.