### PR TITLE
K8SPXC-893 prevent failing of haproxy service

### DIFF
--- a/haproxy/dockerdir/etc/haproxy/haproxy-global.cfg
+++ b/haproxy/dockerdir/etc/haproxy/haproxy-global.cfg
@@ -5,6 +5,7 @@
       stats socket /etc/haproxy/pxc/haproxy.sock mode 600 expose-fd listeners level admin
 
     defaults
+      default-server init-addr last,libc,none
       log global
       mode tcp
       retries 10


### PR DESCRIPTION
[![K8SPXC-893](https://badgen.net/badge/JIRA/K8SPXC-893/green)](https://jira.percona.com/browse/K8SPXC-893) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* haproxy should not fail during the config validation check
      if it can't resolve address of pxc node