### PR TITLE
[ENG-1065] feature: Implemented switch to UBI:8 for PPG

### DIFF
--- a/percona-distribution-postgresql-11/Dockerfile
+++ b/percona-distribution-postgresql-11/Dockerfile
@@ -1,6 +1,9 @@
-FROM centos:8
+FROM redhat/ubi8-minimal
 
 LABEL org.opencontainers.image.authors="info@percona.com"
+
+RUN microdnf -y update; \
+    microdnf -y install glibc-langpack-en
 
 ENV PPG_VERSION 11.13-1
 ENV OS_VER el8
@@ -13,33 +16,56 @@ RUN set -ex; \
     gpg --batch --export --armor 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A > ${GNUPGHOME}/RPM-GPG-KEY-Percona; \
     gpg --batch --export --armor 99DB70FAE1D7CE227FB6488205B555B38483C65D > ${GNUPGHOME}/RPM-GPG-KEY-centosofficial; \
     rpmkeys --import ${GNUPGHOME}/RPM-GPG-KEY-Percona ${GNUPGHOME}/RPM-GPG-KEY-centosofficial; \
+    microdnf install -y findutils; \
     curl -Lf -o /tmp/percona-release.rpm https://repo.percona.com/yum/percona-release-latest.noarch.rpm; \
     rpmkeys --checksig /tmp/percona-release.rpm; \
-    dnf install -y /tmp/percona-release.rpm; \
+    rpm -i /tmp/percona-release.rpm; \
     rm -rf "$GNUPGHOME" /tmp/percona-release.rpm; \
     rpm --import /etc/pki/rpm-gpg/PERCONA-PACKAGING-KEY; \
-    percona-release setup -y ppg11; \
-    percona-release enable ppg-11.10 release
+    #percona-release setup -y ppg11; \
+    percona-release enable ppg-11.13 release
+
+RUN set -ex; \
+    microdnf -y update; \
+    microdnf -y install \
+        bind-utils \
+        gettext \
+        hostname \
+        perl \
+        tar \
+        bzip2 \
+        lz4 \
+        procps-ng; \
+    microdnf -y install  \
+        nss_wrapper \
+        shadow-utils \
+        libpq \
+        libedit; \
+    microdnf clean all
 
 # the numeric UID is needed for OpenShift
 RUN useradd -u 1001 -r -g 0 -s /sbin/nologin \
             -c "Default Application User" postgres
 
 RUN set -ex; \
-    dnf install -y \
-        nss_wrapper \
-        shadow-utils \
+    export GNUPGHOME="$(mktemp -d)"; \
+    curl -Lf -o /tmp/perl-JSON.rpm http://mirror.centos.org/centos/8/AppStream/x86_64/os/Packages/perl-JSON-2.97.001-2.el8.noarch.rpm; \
+    rpmkeys --checksig /tmp/perl-JSON.rpm; \
+    rpm -i /tmp/perl-JSON.rpm
+
+RUN set -ex; \
+    microdnf install -y \
         percona-postgresql11-server-${FULL_PERCONA_VERSION} \
         percona-postgresql11-contrib-${FULL_PERCONA_VERSION} \
         percona-postgresql-common \
         percona-pg-stat-monitor11; \
-    dnf clean all; \
+    microdnf clean all; \
     rm -rf /var/cache/dnf /data/db && mkdir -p /data/db /docker-entrypoint-initdb.d; \
     chown -R 1001:0 /data/db docker-entrypoint-initdb.d
 
 RUN set -ex; \
-	sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/pgsql-11/share/postgresql.conf.sample; \
-	grep -F "listen_addresses = '*'" /usr/pgsql-11/share/postgresql.conf.sample
+    sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/pgsql-11/share/postgresql.conf.sample; \
+    grep -F "listen_addresses = '*'" /usr/pgsql-11/share/postgresql.conf.sample
 
 COPY LICENSE /licenses/LICENSE.Dockerfile
 RUN cp /usr/share/doc/percona-postgresql11/COPYRIGHT /licenses/COPYRIGHT.PostgreSQL

--- a/percona-distribution-postgresql-12/Dockerfile
+++ b/percona-distribution-postgresql-12/Dockerfile
@@ -1,6 +1,9 @@
-FROM centos:8
+FROM redhat/ubi8-minimal
 
 LABEL org.opencontainers.image.authors="info@percona.com"
+
+RUN microdnf -y update; \
+    microdnf -y install glibc-langpack-en
 
 ENV PPG_VERSION 12.8-1
 ENV OS_VER el8
@@ -13,33 +16,56 @@ RUN set -ex; \
     gpg --batch --export --armor 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A > ${GNUPGHOME}/RPM-GPG-KEY-Percona; \
     gpg --batch --export --armor 99DB70FAE1D7CE227FB6488205B555B38483C65D > ${GNUPGHOME}/RPM-GPG-KEY-centosofficial; \
     rpmkeys --import ${GNUPGHOME}/RPM-GPG-KEY-Percona ${GNUPGHOME}/RPM-GPG-KEY-centosofficial; \
+    microdnf install -y findutils; \
     curl -Lf -o /tmp/percona-release.rpm https://repo.percona.com/yum/percona-release-latest.noarch.rpm; \
     rpmkeys --checksig /tmp/percona-release.rpm; \
-    dnf install -y /tmp/percona-release.rpm; \
+    rpm -i /tmp/percona-release.rpm; \
     rm -rf "$GNUPGHOME" /tmp/percona-release.rpm; \
     rpm --import /etc/pki/rpm-gpg/PERCONA-PACKAGING-KEY; \
-    percona-release setup -y ppg12; \
-    percona-release enable ppg-12.5 release
+    #percona-release setup -y ppg12; \
+    percona-release enable ppg-12.8 release
+
+RUN set -ex; \
+    microdnf -y update; \
+    microdnf -y install \
+        bind-utils \
+        gettext \
+        hostname \
+        perl \
+        tar \
+        bzip2 \
+        lz4 \
+        procps-ng; \
+    microdnf -y install  \
+        nss_wrapper \
+        shadow-utils \
+        libpq \
+        libedit; \
+    microdnf clean all
 
 # the numeric UID is needed for OpenShift
 RUN useradd -u 1001 -r -g 0 -s /sbin/nologin \
             -c "Default Application User" postgres
 
 RUN set -ex; \
-    dnf install -y \
-        nss_wrapper \
-        shadow-utils \
+    export GNUPGHOME="$(mktemp -d)"; \
+    curl -Lf -o /tmp/perl-JSON.rpm http://mirror.centos.org/centos/8/AppStream/x86_64/os/Packages/perl-JSON-2.97.001-2.el8.noarch.rpm; \
+    rpmkeys --checksig /tmp/perl-JSON.rpm; \
+    rpm -i /tmp/perl-JSON.rpm
+
+RUN set -ex; \
+    microdnf install -y \
         percona-postgresql12-server-${FULL_PERCONA_VERSION} \
         percona-postgresql12-contrib-${FULL_PERCONA_VERSION} \
         percona-postgresql-common \
         percona-pg-stat-monitor12; \
-    dnf clean all; \
+    microdnf clean all; \
     rm -rf /var/cache/dnf /data/db && mkdir -p /data/db /docker-entrypoint-initdb.d; \
     chown -R 1001:0 /data/db docker-entrypoint-initdb.d
 
 RUN set -ex; \
-	sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/pgsql-12/share/postgresql.conf.sample; \
-	grep -F "listen_addresses = '*'" /usr/pgsql-12/share/postgresql.conf.sample
+    sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/pgsql-12/share/postgresql.conf.sample; \
+    grep -F "listen_addresses = '*'" /usr/pgsql-12/share/postgresql.conf.sample
 
 COPY LICENSE /licenses/LICENSE.Dockerfile
 RUN cp /usr/share/doc/percona-postgresql12/COPYRIGHT /licenses/COPYRIGHT.PostgreSQL

--- a/percona-distribution-postgresql-13/Dockerfile
+++ b/percona-distribution-postgresql-13/Dockerfile
@@ -1,6 +1,9 @@
-FROM centos:8
+FROM redhat/ubi8-minimal
 
 LABEL org.opencontainers.image.authors="info@percona.com"
+
+RUN microdnf -y update; \
+    microdnf -y install glibc-langpack-en
 
 ENV PPG_VERSION 13.4-1
 ENV OS_VER el8
@@ -13,33 +16,56 @@ RUN set -ex; \
     gpg --batch --export --armor 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A > ${GNUPGHOME}/RPM-GPG-KEY-Percona; \
     gpg --batch --export --armor 99DB70FAE1D7CE227FB6488205B555B38483C65D > ${GNUPGHOME}/RPM-GPG-KEY-centosofficial; \
     rpmkeys --import ${GNUPGHOME}/RPM-GPG-KEY-Percona ${GNUPGHOME}/RPM-GPG-KEY-centosofficial; \
+    microdnf install -y findutils; \
     curl -Lf -o /tmp/percona-release.rpm https://repo.percona.com/yum/percona-release-latest.noarch.rpm; \
     rpmkeys --checksig /tmp/percona-release.rpm; \
-    dnf install -y /tmp/percona-release.rpm; \
+    rpm -i /tmp/percona-release.rpm; \
     rm -rf "$GNUPGHOME" /tmp/percona-release.rpm; \
     rpm --import /etc/pki/rpm-gpg/PERCONA-PACKAGING-KEY; \
-    percona-release setup -y ppg13; \
-    percona-release enable ppg-13.1 release
+    #percona-release setup -y ppg13; \
+    percona-release enable ppg-13.4 release
+
+RUN set -ex; \
+    microdnf -y update; \
+    microdnf -y install \
+        bind-utils \
+        gettext \
+        hostname \
+        perl \
+        tar \
+        bzip2 \
+        lz4 \
+        procps-ng; \
+    microdnf -y install  \
+        nss_wrapper \
+        shadow-utils \
+        libpq \
+        libedit; \
+    microdnf clean all
 
 # the numeric UID is needed for OpenShift
 RUN useradd -u 1001 -r -g 0 -s /sbin/nologin \
             -c "Default Application User" postgres
 
 RUN set -ex; \
-    dnf install -y \
-        nss_wrapper \
-        shadow-utils \
+    export GNUPGHOME="$(mktemp -d)"; \
+    curl -Lf -o /tmp/perl-JSON.rpm http://mirror.centos.org/centos/8/AppStream/x86_64/os/Packages/perl-JSON-2.97.001-2.el8.noarch.rpm; \
+    rpmkeys --checksig /tmp/perl-JSON.rpm; \
+    rpm -i /tmp/perl-JSON.rpm
+
+RUN set -ex; \
+    microdnf install -y \
         percona-postgresql13-server-${FULL_PERCONA_VERSION} \
         percona-postgresql13-contrib-${FULL_PERCONA_VERSION} \
         percona-postgresql-common \
         percona-pg-stat-monitor13; \
-    dnf clean all; \
+    microdnf clean all; \
     rm -rf /var/cache/dnf /data/db && mkdir -p /data/db /docker-entrypoint-initdb.d; \
     chown -R 1001:0 /data/db docker-entrypoint-initdb.d
 
 RUN set -ex; \
-	sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/pgsql-13/share/postgresql.conf.sample; \
-	grep -F "listen_addresses = '*'" /usr/pgsql-13/share/postgresql.conf.sample
+    sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/pgsql-13/share/postgresql.conf.sample; \
+    grep -F "listen_addresses = '*'" /usr/pgsql-13/share/postgresql.conf.sample
 
 COPY LICENSE /licenses/LICENSE.Dockerfile
 RUN cp /usr/share/doc/percona-postgresql13/COPYRIGHT /licenses/COPYRIGHT.PostgreSQL

--- a/percona-distribution-postgresql-14/Dockerfile
+++ b/percona-distribution-postgresql-14/Dockerfile
@@ -37,11 +37,11 @@ RUN set -ex; \
         lz4 \
         procps-ng; \
     microdnf -y install  \
-        systemd \
-        libpq \
         nss_wrapper \
+        shadow-utils \
+        libpq \
         libedit; \
-    microdnf -y clean all
+    microdnf clean all
 
 # the numeric UID is needed for OpenShift
 RUN useradd -u 1001 -r -g 0 -s /sbin/nologin \
@@ -55,8 +55,6 @@ RUN set -ex; \
 
 RUN set -ex; \
     microdnf install -y \
-        nss_wrapper \
-        shadow-utils \
         percona-postgresql14-server-${FULL_PERCONA_VERSION} \
         percona-postgresql14-contrib-${FULL_PERCONA_VERSION} \
         percona-postgresql-common \
@@ -66,8 +64,8 @@ RUN set -ex; \
     chown -R 1001:0 /data/db docker-entrypoint-initdb.d
 
 RUN set -ex; \
-	sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/pgsql-14/share/postgresql.conf.sample; \
-	grep -F "listen_addresses = '*'" /usr/pgsql-14/share/postgresql.conf.sample
+    sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/pgsql-14/share/postgresql.conf.sample; \
+    grep -F "listen_addresses = '*'" /usr/pgsql-14/share/postgresql.conf.sample
 
 COPY LICENSE /licenses/LICENSE.Dockerfile
 RUN cp /usr/share/doc/percona-postgresql14/COPYRIGHT /licenses/COPYRIGHT.PostgreSQL


### PR DESCRIPTION
[![ENG-1065](https://badgen.net/badge/JIRA/ENG-1065/green)](https://jira.percona.com/browse/ENG-1065) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

"Tested" with:
```shell
for ver in {11..14}; do cd percona-distribution-postgresql-$ver && sudo docker build -t local-percona-distribution-postgresql-$ver . && cd .. ; done
for ver in {11..14}; do sudo docker run -ti --rm -e POSTGRES_PASSWORD=password local-percona-distribution-postgresql-$ver; done
for ver in {11..14}; do sudo docker rmi local-percona-distribution-postgresql-$ver; done
```

Maybe we should consider switch from `ENV PPG_VERSION 13.4-1` to `ARG` and split it to MINOR and MAJOR, which are passed via `--build-arg` parameter to the `docker build` command. With this approach we can use same `entrypoint.sh` for all PPG versions with `RUN export PPG_VERSION=$value_from_build_argument`.

Also, we can use:
```dockerfile
ENV PPG_VERSION 13.4-1
ENV PPG_UVERSION "${PPG_VERSION%%-*}"
ENV PPG_MAJVERSION "${PPG_UVERSION%%.*}"
ENV PPG_MINVERSION "${PPG_UVERSION#*.}"
```
but this is too fragile.

BTW, we can move following lines (after checking libpq placement):
```dockerfile
ENV PPG_VERSION 11.13-1
ENV OS_VER el8
ENV FULL_PERCONA_VERSION "$PPG_VERSION.$OS_VER"
...
    #percona-release setup -y ppg11; \
    percona-release enable ppg-11.13 release
```
right before
```dockerfile
RUN set -ex; \
    microdnf install -y \
        percona-postgresql11-server-${FULL_PERCONA_VERSION} \
        percona-postgresql11-contrib-${FULL_PERCONA_VERSION} \
        percona-postgresql-common \
        percona-pg-stat-monitor11; \
```
and put gosu installation before PPG install. These may allow us to reuse common layer(s), if we want it