### PR TITLE
K8SPXC-900 disable syncing of mysql and admin variables

### DIFF
--- a/proxysql/dockerdir/etc/proxysql/proxysql.cnf
+++ b/proxysql/dockerdir/etc/proxysql/proxysql.cnf
@@ -8,6 +8,9 @@ admin_variables =
 
 	cluster_username="admin"
 	cluster_password="admin"
+	checksum_admin_variables=false
+	checksum_ldap_variables=false
+	checksum_mysql_variables=false
 	cluster_check_interval_ms=200
 	cluster_check_status_frequency=100
 	cluster_mysql_query_rules_save_to_disk=true


### PR DESCRIPTION
[![K8SPXC-900](https://badgen.net/badge/JIRA/K8SPXC-900/green)](https://jira.percona.com/browse/K8SPXC-900) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* starting from 2.1.0 proxysql started to sync mysql and admin
      variables by default, to have possibility of using custom
      config for proxysql we need to disable it. Users can enable
      it if needed via custom config feature