### PR TITLE
Allow to disable raft for the orchestrator

### DIFF
--- a/orchestrator/dockerdir/entrypoint.sh
+++ b/orchestrator/dockerdir/entrypoint.sh
@@ -12,6 +12,7 @@ if [ -n "$KUBERNETES_SERVICE_HOST" ]; then
                 HTTPAdvertise:\"http://$HOSTNAME.$ORC_SERVICE:80\",
                 RaftAdvertise:\"$HOSTNAME.$ORC_SERVICE\",
                 RaftBind:\"$HOSTNAME.$ORC_SERVICE\",
+                RaftEnabled: ${RAFT_ENABLED:-"true"},
                 MySQLTopologySSLPrivateKeyFile:\"/etc/orchestrator/ssl/tls.key\",
                 MySQLTopologySSLCertFile:\"/etc/orchestrator/ssl/tls.crt\",
                 MySQLTopologySSLCAFile:\"/etc/orchestrator/ssl/ca.crt\",


### PR DESCRIPTION
Allow to disable raft for the orchestrator. As for now PS Operator does not allow to run multiple orchestrator instances