### PR TITLE
K8SPXC-835 add possibly of using proxysql in replica cluster

### DIFF
--- a/proxysql/dockerdir/usr/bin/add_pxc_nodes.sh
+++ b/proxysql/dockerdir/usr/bin/add_pxc_nodes.sh
@@ -62,6 +62,7 @@ function main() {
         --cluster-hostname="$first_host" \
         --enable \
         --update-cluster \
+        --force \
         --remove-all-servers \
         --disable-updates \
         --force \


### PR DESCRIPTION
[![K8SPXC-835](https://badgen.net/badge/JIRA/K8SPXC-835/green)](https://jira.percona.com/browse/K8SPXC-835) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* we had a limitation that proxysql can't be used with
      replica cluster due to limitation on proxyadmin end. It
      was improved and now we can fix it on our end too.
      If --update-cluster is used with the --force flag,
      a warning will be issued (instead of an error) if the
      write-node is a read-only node.