### PR TITLE
K8SPXC-1042 fix 'syntax error' in backup.sh

### DIFF
--- a/percona-xtradb-cluster-5.7-backup/backup.sh
+++ b/percona-xtradb-cluster-5.7-backup/backup.sh
@@ -30,7 +30,7 @@ function get_backup_source() {
         | cut -d . -f 1)
 
     SKIP_FIRST_POD='|'
-    if (( $CLUSTER_SIZE > 1 )); then
+    if (( ${CLUSTER_SIZE:-0} > 1 )); then
         SKIP_FIRST_POD="$FIRST_NODE"
     fi
     peer-list -on-start=/usr/bin/get-pxc-state -service=$PXC_SERVICE 2>&1 \

--- a/percona-xtradb-cluster-8.0-backup/backup.sh
+++ b/percona-xtradb-cluster-8.0-backup/backup.sh
@@ -20,7 +20,7 @@ function get_backup_source() {
         | cut -d . -f 1)
 
     SKIP_FIRST_POD='|'
-    if (( $CLUSTER_SIZE > 1 )); then
+    if (( ${CLUSTER_SIZE:-0} > 1 )); then
         SKIP_FIRST_POD="$FIRST_NODE"
     fi
     peer-list -on-start=/usr/bin/get-pxc-state -service=$PXC_SERVICE 2>&1 \


### PR DESCRIPTION
[![K8SPXC-1042](https://badgen.net/badge/JIRA/K8SPXC-1042/green)](https://jira.percona.com/browse/K8SPXC-1042) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* avoid 'syntax error' in backup.sh in case of not getting
      cluster size