### PR TITLE
CLOUD-734 - HAProxy - remove deprecated option http-use-htx

### DIFF
--- a/haproxy/dockerdir/etc/haproxy/haproxy-global.cfg
+++ b/haproxy/dockerdir/etc/haproxy/haproxy-global.cfg
@@ -41,5 +41,4 @@
     frontend stats
       bind *:8404
       mode http
-      option http-use-htx
       http-request use-service prometheus-exporter if { path /metrics }


### PR DESCRIPTION
[![CLOUD-734](https://badgen.net/badge/JIRA/CLOUD-734/green)](https://jira.percona.com/browse/CLOUD-734) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

`http-use-htx` was deprecated and is now removed and used by default so haproxy doesn't want to start: https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#4-option%20http-use-htx
`Since the version 2.0-dev3, the HTX is the default mode.`