### PR TITLE
K8SPXC-1038 - Fix entrypoint for proxysql

### DIFF
--- a/proxysql/dockerdir/entrypoint.sh
+++ b/proxysql/dockerdir/entrypoint.sh
@@ -5,11 +5,9 @@ set -o xtrace
 PROXY_CFG=/etc/proxysql/proxysql.cnf
 PROXY_ADMIN_CFG=/etc/proxysql-admin.cnf
 
-if [[ -n ${PROXYSQL_SERVICE} ]]; then
-	MYSQL_INTERFACES='0.0.0.0:3306;0.0.0.0:33062'
-	CLUSTER_PORT='33062'
-	sed "s/#export WRITERS_ARE_READERS=.*$/export WRITERS_ARE_READERS='yes'/g" ${PROXY_ADMIN_CFG} 1<>${PROXY_ADMIN_CFG}
-fi
+MYSQL_INTERFACES='0.0.0.0:3306;0.0.0.0:33062'
+CLUSTER_PORT='33062'
+sed "s/#export WRITERS_ARE_READERS=.*$/export WRITERS_ARE_READERS='yes'/g" ${PROXY_ADMIN_CFG} 1<>${PROXY_ADMIN_CFG}
 
 sed "s/interfaces=\"0.0.0.0:3306\"/interfaces=\"${MYSQL_INTERFACES:-0.0.0.0:3306}\"/g" ${PROXY_CFG} 1<>${PROXY_CFG}
 sed "s/stacksize=1048576/stacksize=${MYSQL_STACKSIZE:-1048576}/g" ${PROXY_CFG} 1<>${PROXY_CFG}


### PR DESCRIPTION
[![K8SPXC-1038](https://badgen.net/badge/JIRA/K8SPXC-1038/green)](https://jira.percona.com/browse/K8SPXC-1038) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Remove the `if` because it was always `true` before this change https://github.com/percona/percona-docker/commit/20c2deea12185ca9f161bc05ab14aa252772864c (variable was not quoted), so when we changed [] to [[]] the `if` started filtering and executing conditionally which broke proxysql in our operator images.

This is how we had it set in operator 1.11.0 running images:
```
$ k exec cluster1-proxysql-0 -c proxysql -- env|grep PROXYSQL_SERVICE=
$ k exec cluster1-proxysql-0 -c proxysql-monit -- env|grep PROXYSQL_SERVICE=
PROXYSQL_SERVICE=cluster1-proxysql-unready
$ k exec cluster1-proxysql-0 -c pxc-monit -- env|grep PROXYSQL_SERVICE=
$

$ k exec cluster1-proxysql-0 -c proxysql -- cat /etc/proxysql-admin.cnf|grep WRITERS_ARE_READERS
export WRITERS_ARE_READERS='yes'
$ k exec cluster1-proxysql-0 -c proxysql-monit -- cat /etc/proxysql-admin.cnf|grep WRITERS_ARE_READERS
export WRITERS_ARE_READERS='yes'
$ k exec cluster1-proxysql-0 -c pxc-monit -- cat /etc/proxysql-admin.cnf|grep WRITERS_ARE_READERS
export WRITERS_ARE_READERS='yes'

$ k exec cluster1-proxysql-0 -c proxysql -- cat /etc/proxysql/proxysql.cnf|grep interfaces
        interfaces="0.0.0.0:3306;0.0.0.0:33062"
$ k exec cluster1-proxysql-0 -c proxysql-monit -- cat /etc/proxysql/proxysql.cnf|grep interfaces
        interfaces="0.0.0.0:3306;0.0.0.0:33062"
$ k exec cluster1-proxysql-0 -c pxc-monit -- cat /etc/proxysql/proxysql.cnf|grep interfaces
        interfaces="0.0.0.0:3306;0.0.0.0:33062"
```
so it seems set everywhere regardless if PROXYSQL_SERVICE env variable is set or not and in our `main-proxysql` image that is not true any more.