### PR TITLE
K8SPXC-1157 fix removing of the old backup

### DIFF
--- a/percona-xtradb-cluster-8.0-backup/lib/pxc/backup.sh
+++ b/percona-xtradb-cluster-8.0-backup/lib/pxc/backup.sh
@@ -43,7 +43,7 @@ clean_backup_s3() {
 	mc_add_bucket_dest
 
 	is_object_exist "$S3_BUCKET" "$S3_BUCKET_PATH.$SST_INFO_NAME" || xbcloud delete ${CURL_RET_ERRORS_ARG} ${INSECURE_ARG} --storage=s3 --s3-bucket="$S3_BUCKET" "$S3_BUCKET_PATH.$SST_INFO_NAME"
-	is_object_exist "$S3_BUCKET" "$S3_BUCKET_PATH" || xbcloud delete ${CURL_RET_ERRORS_ARG} ${INSECURE_ARG} --storage=s3 --s3-bucket="$S3_BUCKET" "$S3_BUCKET_PATH"
+	is_object_exist "$S3_BUCKET" "$S3_BUCKET_PATH/" || xbcloud delete ${CURL_RET_ERRORS_ARG} ${INSECURE_ARG} --storage=s3 --s3-bucket="$S3_BUCKET" "$S3_BUCKET_PATH"
 }
 
 azure_auth_header_file() {


### PR DESCRIPTION
[![K8SPXC-1157](https://badgen.net/badge/JIRA/K8SPXC-1157/green)](https://jira.percona.com/browse/K8SPXC-1157) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* PXB has a [bug](https://jira.percona.com/browse/PXB-1854) and it can't delete 'md5sum' file. When mc tries to understand whether the old backup exists or not it detects this md5sum file and thinks that the backup exists and it is needed to delete it. So, we need to check a dir.