### PR TITLE
Reduce percona-xtrabackup docker image size

### DIFF
--- a/percona-xtrabackup-2.4/Dockerfile
+++ b/percona-xtrabackup-2.4/Dockerfile
@@ -25,7 +25,9 @@ RUN set -ex; \
     rm -rf "$GNUPGHOME" /tmp/percona-release.rpm; \
     rpm --import /etc/pki/rpm-gpg/PERCONA-PACKAGING-KEY; \
     #microdnf -y module disable mysql perl-DBD-MySQL; \
-    percona-release enable tools testing
+    percona-release enable tools testing; \
+    microdnf clean all; \
+    rm -rf /var/cache/dnf /var/cache/yum
 
 RUN set -ex; \
     curl -Lf -o /tmp/libev.rpm https://vault.centos.org/centos/8/AppStream/x86_64/os/Packages/libev-4.24-6.el8.x86_64.rpm; \

--- a/percona-xtrabackup-8.0/Dockerfile
+++ b/percona-xtrabackup-8.0/Dockerfile
@@ -28,12 +28,16 @@ RUN set -ex; \
     percona-release disable all; \
     #percona-release setup -y ps-80; \
     percona-release enable ps-80 testing; \
-    percona-release enable tools testing
+    percona-release enable tools testing; \
+    microdnf clean all; \
+    rm -rf /var/cache/dnf /var/cache/yum
 
 RUN set -ex; \
     microdnf -y install \
         tar \
-        shadow-utils
+        shadow-utils; \
+    microdnf clean all; \
+    rm -rf /var/cache/dnf /var/cache/yum
 
 # create mysql user/group before mysql installation
 RUN groupadd -g 1001 mysql; \


### PR DESCRIPTION
```
docker image inspect -f "{{ .Architecture }}-{{ .Size }}" percona/percona-xtrabackup:8.0.32-25
amd64-511926812
```

```
docker image inspect -f "{{ .Architecture }}-{{ .Size }}" local/percona-xtrabackup:8.0.32-25
amd64-408401460
```