### PR TITLE
K8SPXC-989 use IPv4 only

### DIFF
--- a/percona-xtradb-cluster-5.7-backup/backup.sh
+++ b/percona-xtradb-cluster-5.7-backup/backup.sh
@@ -70,7 +70,7 @@ check_ssl() {
 }
 
 request_streaming() {
-	local LOCAL_IP=$(hostname -i)
+	local LOCAL_IP=$(hostname -i | sed -E 's/.*\b([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\b.*/\1/')
 	local NODE_NAME=$(get_backup_source)
 
 	if [ -z "$NODE_NAME" ]; then

--- a/percona-xtradb-cluster-8.0-backup/backup.sh
+++ b/percona-xtradb-cluster-8.0-backup/backup.sh
@@ -67,7 +67,7 @@ function check_ssl() {
 }
 
 function request_streaming() {
-    local LOCAL_IP=$(hostname -i)
+    local LOCAL_IP=$(hostname -i | sed -E 's/.*\b([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\b.*/\1/')
     local NODE_NAME=$(get_backup_source)
 
     if [ -z "$NODE_NAME" ]; then


### PR DESCRIPTION
[![K8SPXC-989](https://badgen.net/badge/JIRA/K8SPXC-989/green)](https://jira.percona.com/browse/K8SPXC-989) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* in case if dual stack (node can have IPv6 and IPv4 IPs) we need to get only IPv4 because operator does not support IPv6