### PR TITLE
K8SPXC-1252 remove installing of krb5-libs rpm from Dockerfile

### DIFF
--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -32,10 +32,6 @@ RUN export GNUPGHOME="$(mktemp -d)" \
 ENV PERCONA_VERSION 8.0.32-24.1.el9
 
 RUN set -ex; \
-	curl -Lf -o /tmp/krb5-libs.rpm https://yum.oracle.com/repo/OracleLinux/OL9/baseos/latest/x86_64/getPackage/krb5-libs-1.19.1-24.0.1.el9_1.x86_64.rpm; \
-	rpmkeys --checksig /tmp/krb5-libs.rpm; \
-	rpm -U /tmp/krb5-libs.rpm; \
-	rm -rf /tmp/krb5-libs.rpm; \
     microdnf install -y \
         shadow-utils \
         percona-haproxy \


### PR DESCRIPTION
[![K8SPXC-1252](https://badgen.net/badge/JIRA/K8SPXC-1252/green)](https://jira.percona.com/browse/K8SPXC-1252) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* krb5-libs  ubi 9 image base image has it, and we do not need to install it