### PR TITLE
Remove krb5-libs.rpm installation from fluentbit image

### DIFF
--- a/fluentbit/Dockerfile
+++ b/fluentbit/Dockerfile
@@ -37,11 +37,8 @@ RUN set -ex; \
     curl -Lf https://github.com/michaloo/go-cron/releases/download/v0.0.2/go-cron.tar.gz -o /tmp/go-cron.tar.gz; \
     tar xvf /tmp/go-cron.tar.gz -C /usr/bin; \
     curl -Lf https://packages.fluentbit.io/centos/8/x86_64/fluent-bit-2.1.4-1.x86_64.rpm -o /tmp/fluent-bit.rpm; \
-    curl -Lf -o /tmp/krb5-libs.rpm https://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/x86_64/getPackage/krb5-libs-1.18.2-22.0.1.el8_7.x86_64.rpm; \
-    rpmkeys --checksig /tmp/procps-ng.rpm /tmp/fluent-bit.rpm /tmp/krb5-libs.rpm; \
-    rpm -U /tmp/krb5-libs.rpm; \
     rpm -i /tmp/fluent-bit.rpm /tmp/procps-ng.rpm --nodeps; \
-    rm -f /tmp/fluent-bit.rpm /tmp/procps-ng.rpm /tmp/krb5-libs.rpm; \
+    rm -f /tmp/fluent-bit.rpm /tmp/procps-ng.rpm; \
     rm -rf /var/cache 
 
 


### PR DESCRIPTION
issue:
```
package krb5-libs-1.18.2-25.el8_8.x86_64 (which is newer than krb5-libs-1.18.2-22.0.1.el8_7.x86_64) is already installed
```