### PR TITLE
K8SPXC-1276 add logformat for haproxy container

### DIFF
--- a/haproxy/dockerdir/entrypoint.sh
+++ b/haproxy/dockerdir/entrypoint.sh
@@ -3,9 +3,9 @@ set -e
 
 log() {
     local message=$1
-    local date=$(/usr/bin/date +"[%d/%b/%Y:%H:%M:%S.%3N]")
+    local date=$(/usr/bin/date +"%d/%b/%Y:%H:%M:%S.%3N")
 
-    echo "${date} ${message}"
+    echo "{\"time\":\"${date}\", \"message\": \"${message}\"}"
 }
 
 if [ "$1" = 'haproxy' ]; then

--- a/haproxy/dockerdir/entrypoint.sh
+++ b/haproxy/dockerdir/entrypoint.sh
@@ -1,17 +1,25 @@
 #!/bin/sh
 set -e
-set -o xtrace
+
+log() {
+    local message=$1
+    local date=$(/usr/bin/date +"[%d/%b/%Y:%H:%M:%S.%3N]")
+
+    echo "${date} ${message}"
+}
 
 if [ "$1" = 'haproxy' ]; then
     if [ ! -f '/etc/haproxy/pxc/haproxy.cfg' ]; then
+        log '/etc/haproxy/haproxy.cfg /etc/haproxy/pxc'
         cp /etc/haproxy/haproxy.cfg /etc/haproxy/pxc
     fi
 
     custom_conf='/etc/haproxy-custom/haproxy-global.cfg'
     if [ -f "$custom_conf" ]; then
+        log "haproxy -c -f $custom_conf -f /etc/haproxy/pxc/haproxy.cfg"
         haproxy -c -f $custom_conf -f /etc/haproxy/pxc/haproxy.cfg || EC=$?
         if [ -n "$EC" ]; then
-            echo "The custom config $custom_conf is not valid and will be ignored."
+            log "The custom config $custom_conf is not valid and will be ignored."
         fi
     fi
 
@@ -24,6 +32,8 @@ if [ "$1" = 'haproxy' ]; then
     haproxy_opt+='-f /etc/haproxy/pxc/haproxy.cfg -p /etc/haproxy/pxc/haproxy.pid -S /etc/haproxy/pxc/haproxy-main.sock '
 fi
 
+log 'test -e /opt/percona/hookscript/hook.sh && source /opt/percona/hookscript/hook.sh'
 test -e /opt/percona/hookscript/hook.sh && source /opt/percona/hookscript/hook.sh
 
+log "$@ $haproxy_opt"
 exec "$@" $haproxy_opt

--- a/haproxy/dockerdir/etc/haproxy/haproxy-global.cfg
+++ b/haproxy/dockerdir/etc/haproxy/haproxy-global.cfg
@@ -1,10 +1,12 @@
     global
+      log stdout format raw local0
       maxconn 2048
       external-check
       insecure-fork-wanted
       stats socket /etc/haproxy/pxc/haproxy.sock mode 600 expose-fd listeners level admin
 
     defaults
+      option tcplog
       default-server init-addr last,libc,none
       log global
       mode tcp

--- a/haproxy/dockerdir/etc/haproxy/haproxy-global.cfg
+++ b/haproxy/dockerdir/etc/haproxy/haproxy-global.cfg
@@ -6,7 +6,8 @@
       stats socket /etc/haproxy/pxc/haproxy.sock mode 600 expose-fd listeners level admin
 
     defaults
-      option tcplog
+      no option dontlognull
+      log-format '{"time":"%t", "client_ip": "%ci", "client_port":"%cp", "backend_source_ip": "%bi", "backend_source_port": "%bp",  "frontend_name": "%ft", "backend_name": "%b", "server_name":"%s", "tw": "%Tw", "tc": "%Tc", "Tt": "%Tt", "bytes_read": "%B", "termination_state": "%ts", "actconn": "%ac", "feconn" :"%fc", "beconn": "%bc", "srv_conn": "%sc", "retries": "%rc", "srv_queue": "%sq", "backend_queue": "%bq" }'
       default-server init-addr last,libc,none
       log global
       mode tcp

--- a/haproxy/dockerdir/usr/bin/add_pxc_nodes.sh
+++ b/haproxy/dockerdir/usr/bin/add_pxc_nodes.sh
@@ -2,7 +2,12 @@
 
 set -o errexit
 
-. /entrypoint.sh
+log() {
+    local message=$1
+    local date=$(/usr/bin/date +"%d/%b/%Y:%H:%M:%S.%3N")
+
+    echo "{\"time\":\"${date}\", \"message\": \"${message}\"}"
+}
 
 function main() {
     log "Running $0"
@@ -132,7 +137,6 @@ EOF
     fi
 
     if [ -S "$path_to_haproxy_cfg/haproxy-main.sock" ]; then
-        log "reload haproxy"
         log "reload | socat stdio $path_to_haproxy_cfg/haproxy-main.sock"
         echo 'reload' | socat stdio "$path_to_haproxy_cfg/haproxy-main.sock"
     fi

--- a/haproxy/dockerdir/usr/bin/add_pxc_nodes.sh
+++ b/haproxy/dockerdir/usr/bin/add_pxc_nodes.sh
@@ -2,12 +2,7 @@
 
 set -o errexit
 
-log() {
-    local message=$1
-    local date=$(/usr/bin/date +"[%d/%b/%Y:%H:%M:%S.%3N]")
-
-    echo "${date} ${message}"
-}
+. /entrypoint.sh
 
 function main() {
     log "Running $0"

--- a/haproxy/dockerdir/usr/bin/add_pxc_nodes.sh
+++ b/haproxy/dockerdir/usr/bin/add_pxc_nodes.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 
 set -o errexit
-set -o xtrace
+
+log() {
+    local message=$1
+    local date=$(/usr/bin/date +"[%d/%b/%Y:%H:%M:%S.%3N]")
+
+    echo "${date} ${message}"
+}
 
 function main() {
-    echo "Running $0"
+    log "Running $0"
 
     NODE_LIST=()
     NODE_LIST_REPL=()
@@ -24,7 +30,7 @@ function main() {
 
     while read pxc_host; do
         if [ -z "$pxc_host" ]; then
-            echo "Could not find PEERS ..."
+            log 'Could not find PEERS ...'
             exit 0
         fi
 
@@ -71,6 +77,7 @@ cat <<-EOF > "$path_to_haproxy_cfg/haproxy.cfg"
       external-check command /usr/local/bin/check_pxc.sh
 EOF
 
+    log "number of available nodes are ${#NODE_LIST_REPL[@]}"
     echo "${#NODE_LIST_REPL[@]}" > $path_to_haproxy_cfg/AVAILABLE_NODES
     ( IFS=$'\n'; echo "${NODE_LIST[*]}" ) >> "$path_to_haproxy_cfg/haproxy.cfg"
 
@@ -123,12 +130,15 @@ EOF
     if [ -n "$main_node" ]; then
          if /usr/local/bin/check_pxc.sh '' '' "$main_node"; then
              for backup_server in ${NODE_LIST_BACKUP[@]}; do
+                 log "shutdown sessions server $backup_server | socat stdio ${SOCKET}"
                  echo "shutdown sessions server $backup_server" | socat stdio "${SOCKET}"
              done
          fi
     fi
 
     if [ -S "$path_to_haproxy_cfg/haproxy-main.sock" ]; then
+        log "reload haproxy"
+        log "reload | socat stdio $path_to_haproxy_cfg/haproxy-main.sock"
         echo 'reload' | socat stdio "$path_to_haproxy_cfg/haproxy-main.sock"
     fi
 }

--- a/haproxy/dockerdir/usr/local/bin/check_pxc.sh
+++ b/haproxy/dockerdir/usr/local/bin/check_pxc.sh
@@ -28,10 +28,11 @@ fi
 
 log() {
     local address=$1
-    local message=$2
-    local date=$(/usr/bin/date +"[%d/%b/%Y:%H:%M:%S.%3N]")
+    local port=$2
+    local message=$3
+    local date=$(/usr/bin/date +"%d/%b/%Y:%H:%M:%S.%3N")
 
-    echo "${address} ${date} ${message}"
+    echo "{\"time\":\"${date}\", \"backend_source_ip\": \"${address}\", \"backend_source_port\": \"${port}\", \"message\": \"${message}\"}"
 }
 
 PXC_NODE_STATUS=($(MYSQL_PWD="${MONITOR_PASSWORD}" $MYSQL_CMDLINE -h $PXC_SERVER_IP -P $PXC_SERVER_PORT \
@@ -41,15 +42,15 @@ PXC_NODE_STATUS=($(MYSQL_PWD="${MONITOR_PASSWORD}" $MYSQL_CMDLINE -h $PXC_SERVER
 # ${PXC_NODE_STATUS[0]} - wsrep_local_state
 # ${PXC_NODE_STATUS[1]} - pxc_maint_mod
 # ${PXC_NODE_STATUS[2]} - wsrep_cluster_status
-log "$PXC_SERVER_IP:$PXC_SERVER_PORT" "The following values are used for PXC node $PXC_SERVER_IP in backend $HAPROXY_PROXY_NAME:"
-log "$PXC_SERVER_IP:$PXC_SERVER_PORT" "wsrep_local_state is ${PXC_NODE_STATUS[0]}; pxc_maint_mod is ${PXC_NODE_STATUS[1]}; wsrep_cluster_status is ${PXC_NODE_STATUS[2]}; $AVAILABLE_NODES nodes are available"
+log "$PXC_SERVER_IP" "$PXC_SERVER_PORT" "The following values are used for PXC node $PXC_SERVER_IP in backend $HAPROXY_PROXY_NAME:"
+log "$PXC_SERVER_IP" "$PXC_SERVER_PORT" "wsrep_local_state is ${PXC_NODE_STATUS[0]}; pxc_maint_mod is ${PXC_NODE_STATUS[1]}; wsrep_cluster_status is ${PXC_NODE_STATUS[2]}; $AVAILABLE_NODES nodes are available"
 if [[ ${PXC_NODE_STATUS[2]} == 'Primary' &&  ( ${PXC_NODE_STATUS[0]} -eq 4 || \
     ${PXC_NODE_STATUS[0]} -eq 2 && ( "${AVAILABLE_NODES}" -le 1 || "${DONOR_IS_OK}" -eq 1 ) ) \
     && ${PXC_NODE_STATUS[1]} == 'DISABLED' ]];
 then
-    log "$PXC_SERVER_IP:$PXC_SERVER_PORT" "PXC node $PXC_SERVER_IP for backend $HAPROXY_PROXY_NAME is ok"
+    log "$PXC_SERVER_IP" "$PXC_SERVER_PORT" "PXC node $PXC_SERVER_IP for backend $HAPROXY_PROXY_NAME is ok"
     exit 0
 else
-    log "$PXC_SERVER_IP:$PXC_SERVER_PORT" "PXC node $PXC_SERVER_IP for backend $HAPROXY_PROXY_NAME is not ok"
+    log "$PXC_SERVER_IP" "$PXC_SERVER_PORT" "PXC node $PXC_SERVER_IP for backend $HAPROXY_PROXY_NAME is not ok"
     exit 1
 fi

--- a/haproxy/dockerdir/usr/local/bin/check_pxc.sh
+++ b/haproxy/dockerdir/usr/local/bin/check_pxc.sh
@@ -29,9 +29,9 @@ fi
 log() {
     local address=$1
     local message=$2
-    local now=$(/usr/bin/date +"[%d/%b/%Y:%H:%M:%S.%3N]")
+    local date=$(/usr/bin/date +"[%d/%b/%Y:%H:%M:%S.%3N]")
 
-    echo "${address} ${now} ${message}"
+    echo "${address} ${date} ${message}"
 }
 
 PXC_NODE_STATUS=($(MYSQL_PWD="${MONITOR_PASSWORD}" $MYSQL_CMDLINE -h $PXC_SERVER_IP -P $PXC_SERVER_PORT \

--- a/haproxy/dockerdir/usr/local/bin/check_pxc.sh
+++ b/haproxy/dockerdir/usr/local/bin/check_pxc.sh
@@ -26,6 +26,14 @@ if [ -f "$path_to_haproxy_cfg/AVAILABLE_NODES" ]; then
     AVAILABLE_NODES=$(/bin/cat $path_to_haproxy_cfg/AVAILABLE_NODES)
 fi
 
+log() {
+    local address=$1
+    local message=$2
+    local now=$(/usr/bin/date +"[%d/%b/%Y:%H:%M:%S.%3N]")
+
+    echo "${address} ${now} ${message}"
+}
+
 PXC_NODE_STATUS=($(MYSQL_PWD="${MONITOR_PASSWORD}" $MYSQL_CMDLINE -h $PXC_SERVER_IP -P $PXC_SERVER_PORT \
         -e "SHOW STATUS LIKE 'wsrep_local_state';SHOW VARIABLES LIKE 'pxc_maint_mode';SHOW GLOBAL STATUS LIKE 'wsrep_cluster_status';" \
         | /usr/bin/grep -A 1 -E 'wsrep_local_state$|pxc_maint_mode$|wsrep_cluster_status$' | /usr/bin/sed -n -e '2p' -e '5p' -e '8p' | /usr/bin/tr '\n' ' '))
@@ -33,15 +41,15 @@ PXC_NODE_STATUS=($(MYSQL_PWD="${MONITOR_PASSWORD}" $MYSQL_CMDLINE -h $PXC_SERVER
 # ${PXC_NODE_STATUS[0]} - wsrep_local_state
 # ${PXC_NODE_STATUS[1]} - pxc_maint_mod
 # ${PXC_NODE_STATUS[2]} - wsrep_cluster_status
-echo "The following values are used for PXC node $PXC_SERVER_IP in backend $HAPROXY_PROXY_NAME:"
-echo "wsrep_local_state is ${PXC_NODE_STATUS[0]}; pxc_maint_mod is ${PXC_NODE_STATUS[1]}; wsrep_cluster_status is ${PXC_NODE_STATUS[2]}; $AVAILABLE_NODES nodes are available"
+log "$PXC_SERVER_IP:$PXC_SERVER_PORT" "The following values are used for PXC node $PXC_SERVER_IP in backend $HAPROXY_PROXY_NAME:"
+log "$PXC_SERVER_IP:$PXC_SERVER_PORT" "wsrep_local_state is ${PXC_NODE_STATUS[0]}; pxc_maint_mod is ${PXC_NODE_STATUS[1]}; wsrep_cluster_status is ${PXC_NODE_STATUS[2]}; $AVAILABLE_NODES nodes are available"
 if [[ ${PXC_NODE_STATUS[2]} == 'Primary' &&  ( ${PXC_NODE_STATUS[0]} -eq 4 || \
     ${PXC_NODE_STATUS[0]} -eq 2 && ( "${AVAILABLE_NODES}" -le 1 || "${DONOR_IS_OK}" -eq 1 ) ) \
     && ${PXC_NODE_STATUS[1]} == 'DISABLED' ]];
 then
-    echo "PXC node $PXC_SERVER_IP for backend $HAPROXY_PROXY_NAME is ok"
+    log "$PXC_SERVER_IP:$PXC_SERVER_PORT" "PXC node $PXC_SERVER_IP for backend $HAPROXY_PROXY_NAME is ok"
     exit 0
 else
-    echo "PXC node $PXC_SERVER_IP for backend $HAPROXY_PROXY_NAME is not ok"
+    log "$PXC_SERVER_IP:$PXC_SERVER_PORT" "PXC node $PXC_SERVER_IP for backend $HAPROXY_PROXY_NAME is not ok"
     exit 1
 fi


### PR DESCRIPTION
[![K8SPXC-1276](https://badgen.net/badge/JIRA/K8SPXC-1276/green)](https://jira.percona.com/browse/K8SPXC-1276) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR fix two issues that were described in K8SPXC-1276 and in K8SPXC-1277

```
> kubectl logs cluster1-haproxy-2 -c haproxy -f
{"time":"24/Jul/2023:14:19:33.050", "backend_source_ip": "10.72.1.20", "backend_source_port": "33062", "message": "The following values are used for PXC node 10.72.1.20 in backend galera-mysqlx-nodes:"}
{"time":"24/Jul/2023:14:19:33.053", "backend_source_ip": "10.72.1.20", "backend_source_port": "33062", "message": "wsrep_local_state is 4; pxc_maint_mod is DISABLED; wsrep_cluster_status is Primary; 3 nodes are available"}
{"time":"24/Jul/2023:14:19:33.056", "backend_source_ip": "10.72.1.20", "backend_source_port": "33062", "message": "PXC node 10.72.1.20 for backend galera-mysqlx-nodes is ok"}
{"time":"24/Jul/2023:14:19:33.580", "client_ip": "127.0.0.1", "client_port":"49064", "backend_source_ip": "10.72.1.24", "backend_source_port": "37562", "frontend_name": "galera-admin-in", "backend_name": "galera-admin-nodes", "server_name":"cluster1-pxc-0", "tw": "1", "tc": "0", "Tt": "44", "bytes_read": "3316", "termination_state": "--", "actconn": "1", "feconn" :"1", "beconn": "0", "srv_conn": "0", "retries": "0", "srv_queue": "0", "backend_queue": "0" }
{"time":"24/Jul/2023:14:19:33.981", "backend_source_ip": "10.72.2.7", "backend_source_port": "33062", "message": "The following values are used for PXC node 10.72.2.7 in backend galera-nodes:"}
{"time":"24/Jul/2023:14:19:33.983", "backend_source_ip": "10.72.2.7", "backend_source_port": "33062", "message": "wsrep_local_state is 4; pxc_maint_mod is DISABLED; wsrep_cluster_status is Primary; 3 nodes are available"}
{"time":"24/Jul/2023:14:19:33.985", "backend_source_ip": "10.72.2.7", "backend_source_port": "33062", "message": "PXC node 10.72.2.7 for backend galera-nodes is ok"}
{"time":"24/Jul/2023:14:19:34.775", "backend_source_ip": "10.72.0.13", "backend_source_port": "33062", "message": "The following values are used for PXC node 10.72.0.13 in backend galera-nodes:"}
{"time":"24/Jul/2023:14:19:34.777", "backend_source_ip": "10.72.0.13", "backend_source_port": "33062", "message": "wsrep_local_state is 4; pxc_maint_mod is DISABLED; wsrep_cluster_status is Primary; 3 nodes are available"}
{"time":"24/Jul/2023:14:19:34.779", "backend_source_ip": "10.72.0.13", "backend_source_port": "33062", "message": "PXC node 10.72.0.13 for backend galera-nodes is ok"}
{"time":"24/Jul/2023:14:19:35.597", "backend_source_ip": "10.72.1.20", "backend_source_port": "33062", "message": "The following values are used for PXC node 10.72.1.20 in backend galera-nodes:"}
{"time":"24/Jul/2023:14:19:35.599", "backend_source_ip": "10.72.1.20", "backend_source_port": "33062", "message": "wsrep_local_state is 4; pxc_maint_mod is DISABLED; wsrep_cluster_status is Primary; 3 nodes are available"}
```