### PR TITLE
Use krb5-libs from distro in proxysql build

### DIFF
--- a/proxysql/Dockerfile
+++ b/proxysql/Dockerfile
@@ -67,6 +67,7 @@ RUN set -ex; \
         procps-ng \
         perl-DBD-MySQL \
         perl-DBI \
+        krb5-libs \
         cpio \
         tar; \
     microdnf clean all; \
@@ -78,14 +79,12 @@ RUN groupadd -g 1001 proxysql; \
 
 # we need licenses from docs
 RUN set -ex; \
-    curl -Lf -o /tmp/krb5-libs.rpm https://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/x86_64/getPackage/krb5-libs-1.18.2-22.0.1.el8_7.x86_64.rpm; \
     curl -Lf -o /tmp/util-linux.rpm http://vault.centos.org/centos/8/BaseOS/x86_64/os/Packages/util-linux-2.32.1-28.el8.x86_64.rpm; \
     curl -Lf -o /tmp/proxysql2-${FULL_PROXYSQL_VERSION}.rpm http://repo.percona.com/proxysql/yum/testing/8/RPMS/x86_64/proxysql2-${FULL_PROXYSQL_VERSION}.x86_64.rpm; \
     curl -Lf -o /tmp/percona-xtradb-cluster-server-${FULL_PERCONA_VERSION}.rpm http://repo.percona.com/pxc-80/yum/release/8.0/RPMS/x86_64/percona-xtradb-cluster-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \
-    rpmkeys --checksig /tmp/percona-xtradb-cluster-server-${FULL_PERCONA_VERSION}.rpm /tmp/proxysql2-${FULL_PROXYSQL_VERSION}.rpm /tmp/util-linux.rpm /tmp/krb5-libs.rpm; \
+    rpmkeys --checksig /tmp/percona-xtradb-cluster-server-${FULL_PERCONA_VERSION}.rpm /tmp/proxysql2-${FULL_PROXYSQL_VERSION}.rpm /tmp/util-linux.rpm; \
     rpm -iv /tmp/proxysql2-${FULL_PROXYSQL_VERSION}.rpm /tmp/util-linux.rpm --nodeps; \
-    rpm -U /tmp/krb5-libs.rpm; \
-    rm -rf /tmp/proxysql2-${FULL_PROXYSQL_VERSION}.rpm /tmp/util-linux.rpm /tmp/krb5-libs.rpm; \
+    rm -rf /tmp/proxysql2-${FULL_PROXYSQL_VERSION}.rpm /tmp/util-linux.rpm; \
     microdnf clean all; \
     rm -rf /var/cache/dnf /var/cache/yum /etc/proxysql /var/lib/proxysql; \
     rpm -ql percona-xtradb-cluster-client | egrep -v "mysql$|mysqldump$" | xargs rm -rf; \

--- a/proxysql/Dockerfile.k8s
+++ b/proxysql/Dockerfile.k8s
@@ -66,6 +66,7 @@ RUN set -ex; \
         procps-ng \
         perl-DBD-MySQL \
         perl-DBI \
+        krb5-libs \
         cpio \
         tar; \
     microdnf clean all; \
@@ -77,14 +78,12 @@ RUN groupadd -g 1001 proxysql; \
 
 # we need licenses from docs
 RUN set -ex; \
-	curl -Lf -o /tmp/krb5-libs.rpm https://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/x86_64/getPackage/krb5-libs-1.18.2-22.0.1.el8_7.x86_64.rpm; \
     curl -Lf -o /tmp/util-linux.rpm http://vault.centos.org/centos/8/BaseOS/x86_64/os/Packages/util-linux-2.32.1-28.el8.x86_64.rpm; \
     curl -Lf -o /tmp/proxysql2-${FULL_PROXYSQL_VERSION}.rpm http://repo.percona.com/proxysql/yum/release/8/RPMS/x86_64/proxysql2-${FULL_PROXYSQL_VERSION}.x86_64.rpm; \
     curl -Lf -o /tmp/percona-xtradb-cluster-server-${FULL_PERCONA_VERSION}.rpm http://repo.percona.com/pxc-80/yum/release/8.0/RPMS/x86_64/percona-xtradb-cluster-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \
-    rpmkeys --checksig /tmp/percona-xtradb-cluster-server-${FULL_PERCONA_VERSION}.rpm /tmp/proxysql2-${FULL_PROXYSQL_VERSION}.rpm /tmp/util-linux.rpm /tmp/krb5-libs.rpm; \
+    rpmkeys --checksig /tmp/percona-xtradb-cluster-server-${FULL_PERCONA_VERSION}.rpm /tmp/proxysql2-${FULL_PROXYSQL_VERSION}.rpm /tmp/util-linux.rpm; \
     rpm -iv /tmp/proxysql2-${FULL_PROXYSQL_VERSION}.rpm /tmp/util-linux.rpm --nodeps; \
-	rpm -U /tmp/krb5-libs.rpm; \
-    rm -rf /tmp/proxysql2-${FULL_PROXYSQL_VERSION}.rpm /tmp/util-linux.rpm /tmp/krb5-libs.rpm; \
+    rm -rf /tmp/proxysql2-${FULL_PROXYSQL_VERSION}.rpm /tmp/util-linux.rpm; \
     microdnf clean all; \
     rm -rf /var/cache/dnf /var/cache/yum /etc/proxysql /var/lib/proxysql; \
     rpm -ql percona-xtradb-cluster-client | egrep -v "mysql$|mysqldump$" | xargs rm -rf; \


### PR DESCRIPTION
proxysql container is currently failing builds with:
```
package krb5-libs-1.18.2-25.el8_8.x86_64 (which is newer than krb5-libs-1.18.2-22.0.1.el8_7.x86_64) is already installed
```