### PR TITLE
K8SPSMDB-1018: Add numactl package installation to percona-server-mon…

### DIFF
--- a/percona-server-mongodb-3.4/Dockerfile
+++ b/percona-server-mongodb-3.4/Dockerfile
@@ -21,7 +21,7 @@ ENV PERCONA_VERSION 3.4.18-2.16.jessie
 RUN \
         apt-get update \
         && apt-get install -y --force-yes \
-           jq percona-server-mongodb-$PERCONA_MAJOR=$PERCONA_VERSION \
+           jq numactl percona-server-mongodb-$PERCONA_MAJOR=$PERCONA_VERSION \
         && rm -rf /var/lib/apt/lists/* \
         && rm -rf /data/db && mkdir -p /data/db \ 
         && chown -R 1001:0 /data/db

--- a/percona-server-mongodb-3.6/Dockerfile
+++ b/percona-server-mongodb-3.6/Dockerfile
@@ -28,6 +28,7 @@ RUN set -ex; \
         procps-ng \
         jq \
         oniguruma \
+        numactl \
         Percona-Server-MongoDB-36-shell-${FULL_PERCONA_VERSION} \
         Percona-Server-MongoDB-36-mongos-${FULL_PERCONA_VERSION}; \
         repoquery -a --location \

--- a/percona-server-mongodb-3.6/Dockerfile.debug
+++ b/percona-server-mongodb-3.6/Dockerfile.debug
@@ -30,6 +30,7 @@ RUN set -ex; \
         telnet \
         gdb \
         nc \
+        numactl \
 		Percona-Server-MongoDB-36-server-debuginfo-${FULL_PERCONA_VERSION} \
 		Percona-Server-MongoDB-36-shell-debuginfo-${FULL_PERCONA_VERSION} \
 		Percona-Server-MongoDB-36-tools-debuginfo-${FULL_PERCONA_VERSION} \

--- a/percona-server-mongodb-3.6/Dockerfile.k8s
+++ b/percona-server-mongodb-3.6/Dockerfile.k8s
@@ -51,6 +51,7 @@ RUN set -ex; \
     microdnf install -y \
         shadow-utils \
         curl \
+        numactl \
         Percona-Server-MongoDB-36-shell-${FULL_PERCONA_VERSION} \
         Percona-Server-MongoDB-36-mongos-${FULL_PERCONA_VERSION}; \
     \

--- a/percona-server-mongodb-4.0/Dockerfile
+++ b/percona-server-mongodb-4.0/Dockerfile
@@ -26,6 +26,7 @@ RUN set -ex; \
     dnf -y install \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-${FULL_PERCONA_VERSION} \
+        numactl \
         procps-ng \
         jq \
         tar \

--- a/percona-server-mongodb-4.0/Dockerfile.debug
+++ b/percona-server-mongodb-4.0/Dockerfile.debug
@@ -30,6 +30,7 @@ RUN set -ex; \
         gdb \
         nc \
         telnet \
+        numactl \
         percona-server-mongodb-server-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-debuginfo-${FULL_PERCONA_VERSION} \

--- a/percona-server-mongodb-4.0/Dockerfile.k8s
+++ b/percona-server-mongodb-4.0/Dockerfile.k8s
@@ -53,6 +53,7 @@ RUN set -ex; \
     microdnf install -y \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-${FULL_PERCONA_VERSION} \
+        numactl \
         shadow-utils \
         curl \
         tar \

--- a/percona-server-mongodb-4.0/Dockerfile.ubi8
+++ b/percona-server-mongodb-4.0/Dockerfile.ubi8
@@ -35,6 +35,7 @@ RUN set -ex; \
     microdnf install -y \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-${FULL_PERCONA_VERSION} \
+        numactl \
         shadow-utils \
         procps-ng \
         tar \

--- a/percona-server-mongodb-4.2/Dockerfile
+++ b/percona-server-mongodb-4.2/Dockerfile
@@ -29,6 +29,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
+        numactl \
         jq \
         procps-ng \
         oniguruma \

--- a/percona-server-mongodb-4.2/Dockerfile.debug
+++ b/percona-server-mongodb-4.2/Dockerfile.debug
@@ -31,6 +31,7 @@ RUN set -ex; \
         nc \
         telnet \
         cyrus-sasl-gssapi \
+        numactl \
         percona-server-mongodb-server-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-debuginfo-${FULL_PERCONA_VERSION} \

--- a/percona-server-mongodb-4.2/Dockerfile.k8s
+++ b/percona-server-mongodb-4.2/Dockerfile.k8s
@@ -54,6 +54,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
+        numactl \
         shadow-utils \
         curl \
         tar \

--- a/percona-server-mongodb-4.2/Dockerfile.ubi8
+++ b/percona-server-mongodb-4.2/Dockerfile.ubi8
@@ -36,6 +36,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
+        numactl \
         shadow-utils \
         curl \
         tar \

--- a/percona-server-mongodb-4.4/Dockerfile
+++ b/percona-server-mongodb-4.4/Dockerfile
@@ -35,6 +35,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
+        numactl \
         procps-ng \
         jq \
         tar \

--- a/percona-server-mongodb-4.4/Dockerfile.aarch64
+++ b/percona-server-mongodb-4.4/Dockerfile.aarch64
@@ -36,6 +36,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-${FULL_PERCONA_VERSION} \
+        numactl \
         procps-ng \
         jq \
         tar \

--- a/percona-server-mongodb-4.4/Dockerfile.debug
+++ b/percona-server-mongodb-4.4/Dockerfile.debug
@@ -34,6 +34,7 @@ RUN set -ex; \
         nc \
         telnet \
         cyrus-sasl-gssapi \
+        numactl \
         percona-server-mongodb-server-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-debuginfo-${FULL_PERCONA_VERSION} \

--- a/percona-server-mongodb-4.4/Dockerfile.k8s
+++ b/percona-server-mongodb-4.4/Dockerfile.k8s
@@ -57,6 +57,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
+        numactl \
         shadow-utils \
         curl \
         tar \

--- a/percona-server-mongodb-4.4/Dockerfile.ubi8
+++ b/percona-server-mongodb-4.4/Dockerfile.ubi8
@@ -45,6 +45,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
+        numactl \
         procps-ng \
         tar \
         cyrus-sasl-gssapi \

--- a/percona-server-mongodb-5.0/Dockerfile
+++ b/percona-server-mongodb-5.0/Dockerfile
@@ -35,6 +35,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
+        numactl \
         procps-ng \
         jq \
         tar \

--- a/percona-server-mongodb-5.0/Dockerfile.aarch64
+++ b/percona-server-mongodb-5.0/Dockerfile.aarch64
@@ -36,6 +36,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-${FULL_PERCONA_VERSION} \
+        numactl \
         procps-ng \
         jq \
         tar \

--- a/percona-server-mongodb-5.0/Dockerfile.debug
+++ b/percona-server-mongodb-5.0/Dockerfile.debug
@@ -34,6 +34,7 @@ RUN set -ex; \
         nc \
         telnet \
         cyrus-sasl-gssapi \
+        numactl \
         percona-server-mongodb-server-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-debuginfo-${FULL_PERCONA_VERSION} \

--- a/percona-server-mongodb-5.0/Dockerfile.k8s
+++ b/percona-server-mongodb-5.0/Dockerfile.k8s
@@ -58,6 +58,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
+        numactl \
         shadow-utils \
         curl \
         tar \

--- a/percona-server-mongodb-5.0/Dockerfile.ubi8
+++ b/percona-server-mongodb-5.0/Dockerfile.ubi8
@@ -39,6 +39,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-shell-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
+        numactl \
         shadow-utils \
         procps-ng \
         tar \

--- a/percona-server-mongodb-6.0/Dockerfile
+++ b/percona-server-mongodb-6.0/Dockerfile
@@ -36,6 +36,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
         percona-mongodb-mongosh \
+        numactl \
         procps-ng \
         jq \
         tar \

--- a/percona-server-mongodb-6.0/Dockerfile.aarch64
+++ b/percona-server-mongodb-6.0/Dockerfile.aarch64
@@ -37,6 +37,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
         percona-mongodb-mongosh \
+        numactl \
         procps-ng \
         jq \
         tar \

--- a/percona-server-mongodb-6.0/Dockerfile.debug
+++ b/percona-server-mongodb-6.0/Dockerfile.debug
@@ -34,6 +34,7 @@ RUN set -ex; \
         nc \
         telnet \
         cyrus-sasl-gssapi \
+        numactl \
         percona-server-mongodb-server-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-mongos-debuginfo-${FULL_PERCONA_VERSION} \

--- a/percona-server-mongodb-6.0/Dockerfile.k8s
+++ b/percona-server-mongodb-6.0/Dockerfile.k8s
@@ -58,6 +58,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
         percona-mongodb-mongosh \
+        numactl \
         shadow-utils \
         curl \
         tar \

--- a/percona-server-mongodb-6.0/Dockerfile.ubi8
+++ b/percona-server-mongodb-6.0/Dockerfile.ubi8
@@ -39,6 +39,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
         percona-mongodb-mongosh \
+        numactl \
         shadow-utils \
         procps-ng \
         tar \

--- a/percona-server-mongodb-6.0/Dockerfile.ubi9
+++ b/percona-server-mongodb-6.0/Dockerfile.ubi9
@@ -35,6 +35,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
         percona-mongodb-mongosh \
+        numactl \
         shadow-utils \
         procps-ng \
         tar \

--- a/percona-server-mongodb-7.0/Dockerfile
+++ b/percona-server-mongodb-7.0/Dockerfile
@@ -36,6 +36,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
         percona-mongodb-mongosh \
+        numactl \
         procps-ng \
         jq \
         tar \

--- a/percona-server-mongodb-7.0/Dockerfile.aarch64
+++ b/percona-server-mongodb-7.0/Dockerfile.aarch64
@@ -37,6 +37,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
         percona-mongodb-mongosh \
+        numactl \
         procps-ng \
         jq \
         tar \

--- a/percona-server-mongodb-7.0/Dockerfile.debug
+++ b/percona-server-mongodb-7.0/Dockerfile.debug
@@ -34,6 +34,7 @@ RUN set -ex; \
         nc \
         telnet \
         cyrus-sasl-gssapi \
+        numactl \
         percona-server-mongodb-server-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-mongos-debuginfo-${FULL_PERCONA_VERSION} \

--- a/percona-server-mongodb-7.0/Dockerfile.k8s
+++ b/percona-server-mongodb-7.0/Dockerfile.k8s
@@ -58,6 +58,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
         percona-mongodb-mongosh \
+        numactl \
         shadow-utils \
         curl \
         tar \

--- a/percona-server-mongodb-7.0/Dockerfile.ubi8
+++ b/percona-server-mongodb-7.0/Dockerfile.ubi8
@@ -39,6 +39,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
         percona-mongodb-mongosh \
+        numactl \
         shadow-utils \
         procps-ng \
         tar \

--- a/percona-server-mongodb-7.0/Dockerfile.ubi9
+++ b/percona-server-mongodb-7.0/Dockerfile.ubi9
@@ -35,6 +35,7 @@ RUN set -ex; \
         percona-server-mongodb-mongos-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
         percona-mongodb-mongosh \
+        numactl \
         shadow-utils \
         procps-ng \
         tar \


### PR DESCRIPTION
[![K8SPSMDB-1018](https://badgen.net/badge/JIRA/K8SPSMDB-1018/green)](https://jira.percona.com/browse/K8SPSMDB-1018) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

***CHANGE DESCRIPTION***
---
**Problem:**
The entrypoint script checks for `numactl` command, but it is not available in the image.

**Cause:**
numactl package is not installed.

**Solution:**
numactl package added for all Dockerfiles where the accompanying ps-entry.sh script contained a `numactl` call.