### PR TITLE
ENG-7 remove psmdb-dbgsrc pkg from psmdb-70 dockers

### DIFF
--- a/percona-server-mongodb-7.0/Dockerfile.debug
+++ b/percona-server-mongodb-7.0/Dockerfile.debug
@@ -38,7 +38,6 @@ RUN set -ex; \
         percona-server-mongodb-server-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-mongos-debuginfo-${FULL_PERCONA_VERSION} \
-        percona-server-mongodb-debugsource-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-${FULL_PERCONA_VERSION}; \
     dnf clean all; \
     rm -rf /var/cache/dnf /var/cache/yum

--- a/percona-server-mongodb-7.0/Dockerfile.k8s
+++ b/percona-server-mongodb-7.0/Dockerfile.k8s
@@ -136,8 +136,7 @@ RUN if [[ -n $DEBUG ]] ; then \
 		    percona-server-mongodb-server-debuginfo-${FULL_PERCONA_VERSION} \
 		    percona-server-mongodb-tools-debuginfo-${FULL_PERCONA_VERSION} \
 		    percona-server-mongodb-mongos-debuginfo-${FULL_PERCONA_VERSION} \
-		    percona-server-mongodb-tools-${FULL_PERCONA_VERSION} \
-		    percona-server-mongodb-debugsource-${FULL_PERCONA_VERSION}; \
+		    percona-server-mongodb-tools-${FULL_PERCONA_VERSION}; \
         microdnf clean all; \
         rm -rf /var/cache/dnf /var/cache/yum; \
     fi


### PR DESCRIPTION
[![ENG-7](https://badgen.net/badge/JIRA/ENG-7/green)](https://jira.percona.com/browse/ENG-7) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

percona-server-mongodb-debugsource pkg is not created for PSMDB-70 so should be removed from Docker files

[ENG-7]: https://perconadev.atlassian.net/browse/ENG-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ