### PR TITLE
K8SPXC-1295 Update Fluent Bit Dockerfile to use newer versions of UBI and Percona

### DIFF
--- a/fluentbit/Dockerfile
+++ b/fluentbit/Dockerfile
@@ -32,7 +32,7 @@ RUN set -ex; \
     percona-xtradb-cluster-client-${PERCONA_VERSION} tar vim-minimal; \
     curl -Lf https://github.com/michaloo/go-cron/releases/download/v0.0.2/go-cron.tar.gz -o /tmp/go-cron.tar.gz; \
     tar xvf /tmp/go-cron.tar.gz -C /usr/bin; \
-    curl -Lf https://packages.fluentbit.io/centos/9/x86_64/fluent-bit-2.1.5-1.x86_64.rpm -o /tmp/fluent-bit.rpm; \
+    curl -Lf https://packages.fluentbit.io/centos/9/x86_64/fluent-bit-2.1.10-1.x86_64.rpm -o /tmp/fluent-bit.rpm; \
     rpmkeys --checksig /tmp/fluent-bit.rpm; \
     rpm -i /tmp/fluent-bit.rpm; \
     rm -rf /var/cache

--- a/fluentbit/Dockerfile
+++ b/fluentbit/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS ubi8
+FROM registry.access.redhat.com/ubi9/ubi-minimal AS ubi9
 
 LABEL name="Fluent Bit" \
       description="Fluent Bit docker image" \
@@ -24,7 +24,7 @@ RUN export GNUPGHOME="$(mktemp -d)" \
     && percona-release setup pdpxc-8.0.32
 
 # install exact version of PS for repeatability
-ENV PERCONA_VERSION 8.0.32-24.1.el9
+ENV PERCONA_VERSION 8.0.35-27.1.el9
 
 # fluentbit does not have el8 repo and the doc suggests installing el7 rpm
 RUN set -ex; \
@@ -35,7 +35,7 @@ RUN set -ex; \
     curl -Lf https://packages.fluentbit.io/centos/9/x86_64/fluent-bit-2.1.5-1.x86_64.rpm -o /tmp/fluent-bit.rpm; \
     rpmkeys --checksig /tmp/fluent-bit.rpm; \
     rpm -i /tmp/fluent-bit.rpm; \
-    rm -rf /var/cache 
+    rm -rf /var/cache
 
 
 RUN groupadd -g 1001 mysql

--- a/fluentbit/Dockerfile
+++ b/fluentbit/Dockerfile
@@ -21,7 +21,7 @@ RUN export GNUPGHOME="$(mktemp -d)" \
     && rpm -i /tmp/percona-release.rpm \
     && rm -rf "$GNUPGHOME" /tmp/percona-release.rpm \
     && rpm --import /etc/pki/rpm-gpg/PERCONA-PACKAGING-KEY \
-    && percona-release setup pdpxc-8.0.32
+    && percona-release setup pdpxc-8.0.35
 
 # install exact version of PS for repeatability
 ENV PERCONA_VERSION 8.0.35-27.1.el9


### PR DESCRIPTION
[![K8SPXC-1295](https://badgen.net/badge/JIRA/K8SPXC-1295/green)](https://jira.percona.com/browse/K8SPXC-1295) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->



[K8SPXC-1295]: https://perconadev.atlassian.net/browse/K8SPXC-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ