### PR TITLE
K8SPG-547: pgbackrest container can't use pgbackrest 2.50

### DIFF
--- a/postgresql-containers/build/pgbackrest/Dockerfile
+++ b/postgresql-containers/build/pgbackrest/Dockerfile
@@ -98,7 +98,7 @@ RUN set -ex; \
     rpmkeys --checksig /tmp/perl-DBI.rpm /tmp/perl-XML-Parser.rpm /tmp/perl-libxml-perl.rpm /tmp/perl-DBD-Pg.rpm; \
     rpm -i /tmp/perl-DBI.rpm /tmp/perl-XML-Parser.rpm /tmp/perl-libxml-perl.rpm /tmp/perl-DBD-Pg.rpm; \
     rm -rf /tmp/perl-DBI.rpm /tmp/perl-XML-Parser.rpm /tmp/perl-libxml-perl.rpm /tmp/perl-DBD-Pg.rpm; \
-    microdnf -y install  \
+    microdnf -y --enablerepo=epel install  \
         percona-pgbackrest; \
     microdnf -y clean all
 


### PR DESCRIPTION
[![K8SPG-547](https://badgen.net/badge/JIRA/K8SPG-547/green)](https://jira.percona.com/browse/K8SPG-547) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

pgbackrest 2.50 requires libssh2.so.1, which requires epel.

```
$ diff --color <(rpm -qR percona-pgbackrest-2.48-1.el8.x86_64.rpm 2>&1) <(rpm -qR percona-pgbackrest-2.50-1.el8.x86_64.rpm 2>&1)
1,2c1,2
< warning: percona-pgbackrest-2.48-1.el8.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 8507efa5: NOKEY
< config(percona-pgbackrest) = 1:2.48-1.el8
---
> warning: percona-pgbackrest-2.50-1.el8.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 8507efa5: NOKEY
> config(percona-pgbackrest) = 1:2.50-1.el8
14a15
> liblz4.so.1()(64bit)
15a17
> libssh2.so.1()(64bit)
21a24
> libzstd.so.1()(64bit)
```

Without that fix `microdnf` installs pgbackrest 2.48 which creates inconsitency with postgresql container.

[K8SPG-547]: https://perconadev.atlassian.net/browse/K8SPG-547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ