### PR TITLE
K8SPG-547 pgbackrest container can't use pgbackrest 2.50 for repo image

### DIFF
--- a/postgresql-containers/build/pgbackrest-repo/Dockerfile
+++ b/postgresql-containers/build/pgbackrest-repo/Dockerfile
@@ -96,7 +96,7 @@ RUN set -ex; \
     rpmkeys --checksig /tmp/perl-DBI.rpm /tmp/perl-XML-Parser.rpm /tmp/perl-libxml-perl.rpm /tmp/perl-DBD-Pg.rpm; \
     rpm -i /tmp/perl-DBI.rpm /tmp/perl-XML-Parser.rpm /tmp/perl-libxml-perl.rpm /tmp/perl-DBD-Pg.rpm; \
     rm -rf /tmp/perl-DBI.rpm /tmp/perl-XML-Parser.rpm /tmp/perl-libxml-perl.rpm /tmp/perl-DBD-Pg.rpm; \
-    microdnf -y install  \
+    microdnf -y --enablerepo=epel install  \
         percona-pgbackrest; \
     microdnf -y clean all
 


### PR DESCRIPTION
[![K8SPG-547](https://badgen.net/badge/JIRA/K8SPG-547/green)](https://jira.percona.com/browse/K8SPG-547) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->



[K8SPG-547]: https://perconadev.atlassian.net/browse/K8SPG-547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ