### PR TITLE
PBM-1396. Use ubi8 as base image for PBM ARM docker

### DIFF
--- a/percona-backup-mongodb/Dockerfile.aarch64
+++ b/percona-backup-mongodb/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM redhat/ubi9-minimal
+FROM redhat/ubi8-minimal
 
 # Please don't remove old-style LABEL since it's needed for RedHat certification
 LABEL name="Percona Backup for MongoDB" \
@@ -15,8 +15,8 @@ LABEL org.opencontainers.image.title="Percona Backup for MongoDB" \
     org.opencontainers.image.authors="info@percona.com"
 
 ENV PBM_VERSION 2.6.0-1
-ENV PBM_REPO_CH experimental
-ENV OS_VER el9
+ENV PBM_REPO_CH release
+ENV OS_VER el8
 ENV FULL_PBM_VERSION "$PBM_VERSION.$OS_VER"
 
 # check repository package signature in secure way


### PR DESCRIPTION
[![PBM-1396](https://badgen.net/badge/JIRA/PBM-1396/green)](https://jira.percona.com/browse/PBM-1396) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->



[PBM-1396]: https://perconadev.atlassian.net/browse/PBM-1396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ