### PR TITLE
Allow proxysql entrypoint to work with helm config

### DIFF
--- a/proxysql/Dockerfile
+++ b/proxysql/Dockerfile
@@ -98,4 +98,4 @@ VOLUME /var/lib/proxysql
 ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 3306 6032
-CMD ["/usr/bin/proxysql", "-f", "-c", "/etc/proxysql/proxysql.cnf", "--reload"]
+CMD ["/usr/bin/proxysql", "-f", "-c", "/etc/proxysql.cnf", "--reload"]

--- a/proxysql/dockerdir/entrypoint.sh
+++ b/proxysql/dockerdir/entrypoint.sh
@@ -2,13 +2,15 @@
 
 set -o xtrace
 
-PROXY_CFG=/etc/proxysql/proxysql.cnf
+PROXY_CFG_SRC=/etc/proxysql/proxysql.cnf
+PROXY_CFG=/etc/proxysql.cnf
 PROXY_ADMIN_CFG=/etc/proxysql-admin.cnf
 
 MYSQL_INTERFACES='0.0.0.0:3306;0.0.0.0:33062'
 CLUSTER_PORT='33062'
 sed "s/#export WRITERS_ARE_READERS=.*$/export WRITERS_ARE_READERS='yes'/g" ${PROXY_ADMIN_CFG} 1<>${PROXY_ADMIN_CFG}
 
+cp ${PROXY_CFG_SRC} ${PROXY_CFG}
 sed "s/interfaces=\"0.0.0.0:3306\"/interfaces=\"${MYSQL_INTERFACES:-0.0.0.0:3306}\"/g" ${PROXY_CFG} 1<>${PROXY_CFG}
 sed "s/stacksize=1048576/stacksize=${MYSQL_STACKSIZE:-1048576}/g" ${PROXY_CFG} 1<>${PROXY_CFG}
 sed "s/threads=2/threads=${MYSQL_THREADS:-2}/g" ${PROXY_CFG} 1<>${PROXY_CFG}


### PR DESCRIPTION
The current entrypoint script attempts to modify `/etc/proxysql/proxysql.cnf` using sed (replacing sensitive data such as usernames / passwords with environment variables) however when deploying proxysql as part of the `pxc-db` helm chart, where `proxysql.configuration` is specified, a configmap  (`mysql-db-proxysql`) is created and mounted to the `/etc/proxysql` path, which is by definition read only.

As a result, the entrypoint script generates errors on startup, but also prevents the usage of the generic values such as `admin:admin` which would otherwise be replaced by environment variables in `entrypoint.sh`, forcing the hardcoding of these values in a helm config which is not secure.

The proposed change simply copies the config file form `/etc/proxysql/proxysql.cnf` to `/etc/proxysql.cnf` before performing the modifications, and then uses that config file when starting proxysql.