### PR TITLE
K8SPG-652 upstream operator does not support pgbackrest 2.54

### DIFF
--- a/postgresql-containers/build/pgbackrest/Dockerfile
+++ b/postgresql-containers/build/pgbackrest/Dockerfile
@@ -79,7 +79,7 @@ RUN set -ex; \
 
 RUN set -ex; \
     microdnf -y install \
-        percona-pgbackrest; \
+        percona-pgbackrest-2.53; \
     microdnf -y clean all
 
 RUN set -ex; \

--- a/postgresql-containers/build/postgres/Dockerfile
+++ b/postgresql-containers/build/postgres/Dockerfile
@@ -97,7 +97,7 @@ RUN set -ex; \
         --enablerepo="ol9_developer_EPEL" \
         percona-pgaudit${PG_MAJOR//.} \
         percona-pgaudit${PG_MAJOR//.}_set_user \
-        percona-pgbackrest \
+        percona-pgbackrest-2.53 \
         percona-postgresql${PG_MAJOR//.}-contrib \
         percona-postgresql${PG_MAJOR//.}-server \
         percona-postgresql${PG_MAJOR//.}-libs \


### PR DESCRIPTION
[![K8SPG-652](https://badgen.net/badge/JIRA/K8SPG-652/green)](https://jira.percona.com/browse/K8SPG-652) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->



[K8SPG-652]: https://perconadev.atlassian.net/browse/K8SPG-652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ