### PR TITLE
[PKG-289]: Updates xtrabackup Dockerfiles to use ubi9-minimal as base…

### DIFF
--- a/percona-xtrabackup-2.4/Dockerfile
+++ b/percona-xtrabackup-2.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM redhat/ubi8-minimal
+FROM redhat/ubi9-minimal
 
 LABEL org.opencontainers.image.authors="info@percona.com"
 
@@ -7,7 +7,7 @@ RUN microdnf -y update; \
 
 ENV XTRABACKUP_VERSION 2.4.29-1
 ENV PS_VERSION 5.7.44-48.1
-ENV OS_VER el8
+ENV OS_VER el9
 ENV FULL_PERCONA_VERSION "$PS_VERSION.$OS_VER"
 ENV FULL_PERCONA_XTRABACKUP_VERSION "$XTRABACKUP_VERSION.$OS_VER"
 
@@ -25,10 +25,11 @@ RUN set -ex; \
     rm -rf "$GNUPGHOME" /tmp/percona-release.rpm; \
     rpm --import /etc/pki/rpm-gpg/PERCONA-PACKAGING-KEY; \
     #microdnf -y module disable mysql perl-DBD-MySQL; \
-    percona-release enable tools testing
+    percona-release enable tools testing; \
+    percona-release enable ps-57 testing
 
 RUN set -ex; \
-    curl -Lf -o /tmp/libev.rpm https://vault.centos.org/centos/8/AppStream/x86_64/os/Packages/libev-4.24-6.el8.x86_64.rpm; \
+    curl -Lf -o /tmp/libev.rpm https://downloads.percona.com/downloads/packaging/libev-4.33-5.el9.x86_64.rpm; \
     rpm -i /tmp/libev.rpm; \
     rm -rf /tmp/libev.rpm; \
     #dnf --setopt=install_weak_deps=False install -y \

--- a/percona-xtrabackup-8.x/Dockerfile
+++ b/percona-xtrabackup-8.x/Dockerfile
@@ -1,4 +1,4 @@
-FROM redhat/ubi8-minimal
+FROM redhat/ubi9-minimal
 
 LABEL org.opencontainers.image.authors="info@percona.com"
 
@@ -7,7 +7,7 @@ RUN microdnf -y update; \
 
 ENV XTRABACKUP_VERSION 8.4.0-1.1
 ENV PS_VERSION 8.3.0-1.1
-ENV OS_VER el8
+ENV OS_VER el9
 ENV FULL_PERCONA_VERSION "$PS_VERSION.$OS_VER"
 ENV FULL_PERCONA_XTRABACKUP_VERSION "$XTRABACKUP_VERSION.$OS_VER"
 
@@ -42,7 +42,7 @@ RUN groupadd -g 1001 mysql; \
         -c "Default Application User" mysql
 
 RUN set -ex; \
-    curl -Lf -o /tmp/libev.rpm http://vault.centos.org/centos/8/AppStream/x86_64/os/Packages/libev-4.24-6.el8.x86_64.rpm; \
+    curl -Lf -o /tmp/libev.rpm https://downloads.percona.com/downloads/packaging/libev-4.33-5.el9.x86_64.rpm; \
     rpm -i /tmp/libev.rpm; \
     rm -rf /tmp/libev.rpm; \
     #dnf --setopt=install_weak_deps=False --best install -y \


### PR DESCRIPTION
[![PKG-289](https://badgen.net/badge/JIRA/PKG-289/green)](https://jira.percona.com/browse/PKG-289) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

… image.

[PKG-289]: https://perconadev.atlassian.net/browse/PKG-289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ