### PR TITLE
PBM-1476. Override maintainer label included in base image

### DIFF
--- a/percona-backup-mongodb/Dockerfile
+++ b/percona-backup-mongodb/Dockerfile
@@ -2,6 +2,7 @@ FROM redhat/ubi9-minimal
 
 # Please don't remove old-style LABEL since it's needed for RedHat certification
 LABEL name="Percona Backup for MongoDB" \
+    maintainer="Percona Development <info@percona.com>" \
     vendor="Percona" \
     summary="Percona Backup for MongoDB" \
     description="Percona Backup for MongoDB is a distributed, \

--- a/percona-backup-mongodb/Dockerfile.aarch64
+++ b/percona-backup-mongodb/Dockerfile.aarch64
@@ -2,6 +2,7 @@ FROM redhat/ubi9-minimal
 
 # Please don't remove old-style LABEL since it's needed for RedHat certification
 LABEL name="Percona Backup for MongoDB" \
+    maintainer="Percona Development <info@percona.com>" \
     vendor="Percona" \
     summary="Percona Backup for MongoDB" \
     description="Percona Backup for MongoDB is a distributed, \


### PR DESCRIPTION
[![PBM-1476](https://badgen.net/badge/JIRA/PBM-1476/green)](https://jira.percona.com/browse/PBM-1476) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Labels included in base images are inherited, so it's required to override the existing maintainer label. The value is set the same as in other products.

[PBM-1476]: https://perconadev.atlassian.net/browse/PBM-1476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ