### PR TITLE
Use more stable syntax dockerfile:1 instead of master

### DIFF
--- a/postgresql-containers/build/postgres/Dockerfile
+++ b/postgresql-containers/build/postgres/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile-upstream:master
+# syntax=docker/dockerfile:1
 
 FROM golang:1.22 AS go_builder
 WORKDIR /go/src/github.com/mikefarah/yq


### PR DESCRIPTION
Based on Docker documentation `dockerfile-upstream:master` has all the latest fixes and can be unstable. Usage of  latest released is more recommended `syntax=docker/dockerfile:1`.