### PR TITLE
K8SPXC-1475 fix azure check for existing object

### DIFF
--- a/percona-xtradb-cluster-5.7-backup/backup.sh
+++ b/percona-xtradb-cluster-5.7-backup/backup.sh
@@ -178,21 +178,33 @@ backup_s3() {
 }
 
 azure_auth_header_file() {
+	local params="$1"
+	local request_date="$2"
+	local hex_tmp
+	local signature_tmp
+	local auth_header_tmp
+	local resource
+	local string_to_sign
+	local decoded_key
+
 	hex_tmp=$(mktemp)
 	signature_tmp=$(mktemp)
 	auth_header_tmp=$(mktemp)
 
-	params="$1"
-	request_date="$2"
+	decoded_key=$(echo -n "$AZURE_ACCESS_KEY" | base64 -d | hexdump -ve '1/1 "%02x"')
+	echo -n "$decoded_key" >"$hex_tmp"
 
-	{ set +x; } 2>/dev/null
-	echo -n "$AZURE_ACCESS_KEY" | base64 -d -w0 | hexdump -ve '1/1 "%02x"' >"$hex_tmp"
-	headers="x-ms-date:$request_date\nx-ms-version:2021-06-08"
 	resource="/$AZURE_STORAGE_ACCOUNT/$AZURE_CONTAINER_NAME"
-	string_to_sign="GET\n\n\n\n\n\n\n\n\n\n\n\n${headers}\n${resource}\n${params}"
-	printf '%s' "$string_to_sign" | openssl dgst -sha256 -mac HMAC -macopt "hexkey:$(cat "$hex_tmp")" -binary | base64 -w0 >"$signature_tmp"
+
+	string_to_sign=$(printf "GET\n\n\n\n\n\n\n\n\n\n\n\nx-ms-date:%s\nx-ms-version:2021-06-08\n%s\n%s" \
+		"$request_date" \
+		"$resource" \
+		"$params")
+
+	printf "%s" "$string_to_sign" | openssl dgst -sha256 -mac HMAC -macopt "hexkey:$(cat "$hex_tmp")" -binary | base64 >"$signature_tmp"
+
 	echo -n "Authorization: SharedKey $AZURE_STORAGE_ACCOUNT:$(cat "$signature_tmp")" >"$auth_header_tmp"
-	set -x
+
 	echo "$auth_header_tmp"
 }
 
@@ -203,9 +215,9 @@ is_object_exist_azure() {
 	request_date=$(LC_ALL=en_US.utf8 TZ=GMT date "+%a, %d %h %Y %H:%M:%S %Z")
 	header_version="x-ms-version: 2021-06-08"
 	header_date="x-ms-date: $request_date"
-	header_auth_file=$(azure_auth_header_file "comp:list\nrestype:container" "$request_date")
+	header_auth_file=$(azure_auth_header_file $'comp:list\nrestype:container' "$request_date")
 
-	res=$(curl -s -H "$header_version" -H "$header_date" -H "@$header_auth_file" ${connection_string} | grep $object)
+	res=$(curl -s -H "$header_version" -H "$header_date" -H "@$header_auth_file" "${connection_string}" | grep "$object")
 	set -x
 
 	if [[ ${#res} -ne 0 ]]; then

--- a/percona-xtradb-cluster-5.7-backup/backup.sh
+++ b/percona-xtradb-cluster-5.7-backup/backup.sh
@@ -211,13 +211,14 @@ azure_auth_header_file() {
 is_object_exist_azure() {
 	object="$1"
 	{ set +x; } 2>/dev/null
-	connection_string="$ENDPOINT/$AZURE_CONTAINER_NAME?comp=list&restype=container"
+	connection_string="$ENDPOINT/$AZURE_CONTAINER_NAME?comp=list&restype=container&prefix=$object"
 	request_date=$(LC_ALL=en_US.utf8 TZ=GMT date "+%a, %d %h %Y %H:%M:%S %Z")
 	header_version="x-ms-version: 2021-06-08"
 	header_date="x-ms-date: $request_date"
-	header_auth_file=$(azure_auth_header_file $'comp:list\nrestype:container' "$request_date")
+	header_auth_file=$(azure_auth_header_file "$(printf 'comp:list\nprefix:%s\nrestype:container' "$object")" "$request_date")
 
-	res=$(curl -s -H "$header_version" -H "$header_date" -H "@$header_auth_file" "${connection_string}" | grep "$object")
+	response=$(curl -s -H "$header_version" -H "$header_date" -H "@$header_auth_file" "${connection_string}")
+	res=$(echo "$response" | grep "<Blob>")
 	set -x
 
 	if [[ ${#res} -ne 0 ]]; then

--- a/percona-xtradb-cluster-8.0-backup/lib/pxc/backup.sh
+++ b/percona-xtradb-cluster-8.0-backup/lib/pxc/backup.sh
@@ -67,13 +67,14 @@ azure_auth_header_file() {
 is_object_exist_azure() {
 	object="$1"
 	{ set +x; } 2>/dev/null
-	connection_string="$ENDPOINT/$AZURE_CONTAINER_NAME?comp=list&restype=container"
+	connection_string="$ENDPOINT/$AZURE_CONTAINER_NAME?comp=list&restype=container&prefix=$object"
 	request_date=$(LC_ALL=en_US.utf8 TZ=GMT date "+%a, %d %h %Y %H:%M:%S %Z")
 	header_version="x-ms-version: 2021-06-08"
 	header_date="x-ms-date: $request_date"
-	header_auth_file=$(azure_auth_header_file $'comp:list\nrestype:container' "$request_date")
+	header_auth_file=$(azure_auth_header_file "$(printf 'comp:list\nprefix:%s\nrestype:container' "$object")" "$request_date")
 
-	res=$(curl -s -H "$header_version" -H "$header_date" -H "@$header_auth_file" "${connection_string}" | grep "$object")
+	response=$(curl -s -H "$header_version" -H "$header_date" -H "@$header_auth_file" "${connection_string}")
+	res=$(echo "$response" | grep "<Blob>")
 	set -x
 
 	if [[ ${#res} -ne 0 ]]; then

--- a/percona-xtradb-cluster-8.0-backup/lib/pxc/backup.sh
+++ b/percona-xtradb-cluster-8.0-backup/lib/pxc/backup.sh
@@ -34,21 +34,33 @@ clean_backup_s3() {
 }
 
 azure_auth_header_file() {
+	local params="$1"
+	local request_date="$2"
+	local hex_tmp
+	local signature_tmp
+	local auth_header_tmp
+	local resource
+	local string_to_sign
+	local decoded_key
+
 	hex_tmp=$(mktemp)
 	signature_tmp=$(mktemp)
 	auth_header_tmp=$(mktemp)
 
-	params="$1"
-	request_date="$2"
+	decoded_key=$(echo -n "$AZURE_ACCESS_KEY" | base64 -d | hexdump -ve '1/1 "%02x"')
+	echo -n "$decoded_key" >"$hex_tmp"
 
-	{ set +x; } 2>/dev/null
-	echo -n "$AZURE_ACCESS_KEY" | base64 -d -w0 | hexdump -ve '1/1 "%02x"' >"$hex_tmp"
-	headers="x-ms-date:$request_date\nx-ms-version:2021-06-08"
 	resource="/$AZURE_STORAGE_ACCOUNT/$AZURE_CONTAINER_NAME"
-	string_to_sign="GET\n\n\n\n\n\n\n\n\n\n\n\n${headers}\n${resource}\n${params}"
-	printf '%s' "$string_to_sign" | openssl dgst -sha256 -mac HMAC -macopt "hexkey:$(cat "$hex_tmp")" -binary | base64 -w0 >"$signature_tmp"
+
+	string_to_sign=$(printf "GET\n\n\n\n\n\n\n\n\n\n\n\nx-ms-date:%s\nx-ms-version:2021-06-08\n%s\n%s" \
+		"$request_date" \
+		"$resource" \
+		"$params")
+
+	printf "%s" "$string_to_sign" | openssl dgst -sha256 -mac HMAC -macopt "hexkey:$(cat "$hex_tmp")" -binary | base64 >"$signature_tmp"
+
 	echo -n "Authorization: SharedKey $AZURE_STORAGE_ACCOUNT:$(cat "$signature_tmp")" >"$auth_header_tmp"
-	set -x
+
 	echo "$auth_header_tmp"
 }
 
@@ -59,7 +71,7 @@ is_object_exist_azure() {
 	request_date=$(LC_ALL=en_US.utf8 TZ=GMT date "+%a, %d %h %Y %H:%M:%S %Z")
 	header_version="x-ms-version: 2021-06-08"
 	header_date="x-ms-date: $request_date"
-	header_auth_file=$(azure_auth_header_file "comp:list\nrestype:container" "$request_date")
+	header_auth_file=$(azure_auth_header_file $'comp:list\nrestype:container' "$request_date")
 
 	res=$(curl -s -H "$header_version" -H "$header_date" -H "@$header_auth_file" "${connection_string}" | grep "$object")
 	set -x

--- a/percona-xtradb-cluster-8.4-backup/lib/pxc/backup.sh
+++ b/percona-xtradb-cluster-8.4-backup/lib/pxc/backup.sh
@@ -67,13 +67,14 @@ azure_auth_header_file() {
 is_object_exist_azure() {
 	object="$1"
 	{ set +x; } 2>/dev/null
-	connection_string="$ENDPOINT/$AZURE_CONTAINER_NAME?comp=list&restype=container"
+	connection_string="$ENDPOINT/$AZURE_CONTAINER_NAME?comp=list&restype=container&prefix=$object"
 	request_date=$(LC_ALL=en_US.utf8 TZ=GMT date "+%a, %d %h %Y %H:%M:%S %Z")
 	header_version="x-ms-version: 2021-06-08"
 	header_date="x-ms-date: $request_date"
-	header_auth_file=$(azure_auth_header_file $'comp:list\nrestype:container' "$request_date")
+	header_auth_file=$(azure_auth_header_file "$(printf 'comp:list\nprefix:%s\nrestype:container' "$object")" "$request_date")
 
-	res=$(curl -s -H "$header_version" -H "$header_date" -H "@$header_auth_file" "${connection_string}" | grep "$object")
+	response=$(curl -s -H "$header_version" -H "$header_date" -H "@$header_auth_file" "${connection_string}")
+	res=$(echo "$response" | grep "<Blob>")
 	set -x
 
 	if [[ ${#res} -ne 0 ]]; then

--- a/percona-xtradb-cluster-8.4-backup/lib/pxc/backup.sh
+++ b/percona-xtradb-cluster-8.4-backup/lib/pxc/backup.sh
@@ -34,21 +34,33 @@ clean_backup_s3() {
 }
 
 azure_auth_header_file() {
+	local params="$1"
+	local request_date="$2"
+	local hex_tmp
+	local signature_tmp
+	local auth_header_tmp
+	local resource
+	local string_to_sign
+	local decoded_key
+
 	hex_tmp=$(mktemp)
 	signature_tmp=$(mktemp)
 	auth_header_tmp=$(mktemp)
 
-	params="$1"
-	request_date="$2"
+	decoded_key=$(echo -n "$AZURE_ACCESS_KEY" | base64 -d | hexdump -ve '1/1 "%02x"')
+	echo -n "$decoded_key" >"$hex_tmp"
 
-	{ set +x; } 2>/dev/null
-	echo -n "$AZURE_ACCESS_KEY" | base64 -d -w0 | hexdump -ve '1/1 "%02x"' >"$hex_tmp"
-	headers="x-ms-date:$request_date\nx-ms-version:2021-06-08"
 	resource="/$AZURE_STORAGE_ACCOUNT/$AZURE_CONTAINER_NAME"
-	string_to_sign="GET\n\n\n\n\n\n\n\n\n\n\n\n${headers}\n${resource}\n${params}"
-	printf '%s' "$string_to_sign" | openssl dgst -sha256 -mac HMAC -macopt "hexkey:$(cat "$hex_tmp")" -binary | base64 -w0 >"$signature_tmp"
+
+	string_to_sign=$(printf "GET\n\n\n\n\n\n\n\n\n\n\n\nx-ms-date:%s\nx-ms-version:2021-06-08\n%s\n%s" \
+		"$request_date" \
+		"$resource" \
+		"$params")
+
+	printf "%s" "$string_to_sign" | openssl dgst -sha256 -mac HMAC -macopt "hexkey:$(cat "$hex_tmp")" -binary | base64 >"$signature_tmp"
+
 	echo -n "Authorization: SharedKey $AZURE_STORAGE_ACCOUNT:$(cat "$signature_tmp")" >"$auth_header_tmp"
-	set -x
+
 	echo "$auth_header_tmp"
 }
 
@@ -59,7 +71,7 @@ is_object_exist_azure() {
 	request_date=$(LC_ALL=en_US.utf8 TZ=GMT date "+%a, %d %h %Y %H:%M:%S %Z")
 	header_version="x-ms-version: 2021-06-08"
 	header_date="x-ms-date: $request_date"
-	header_auth_file=$(azure_auth_header_file "comp:list\nrestype:container" "$request_date")
+	header_auth_file=$(azure_auth_header_file $'comp:list\nrestype:container' "$request_date")
 
 	res=$(curl -s -H "$header_version" -H "$header_date" -H "@$header_auth_file" "${connection_string}" | grep "$object")
 	set -x


### PR DESCRIPTION
[![K8SPXC-1475](https://badgen.net/badge/JIRA/K8SPXC-1475/green)](https://jira.percona.com/browse/K8SPXC-1475) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

In the PR we introduce a fix for the checking of the existence of backup objects in Azure storage. We are slightly refactoring the logic so that instead of querying the whole storage and then grepping the response for the searched object, we use URL params with our object prefix and search the response for non-empty blobs. The problem of fetching the whole storage space and then using grep, is that Azure API is paginating the results, so with our initial approach on this PR, we had flaky behaviour given that our object may not be present in the 1st page of the results.. 

How to reproduce the issue:
- Start a pxc backup and kill the pod with `--force` after 'successfully uploaded chunk' is logged
- Wait until the restarted pod is started by the job. The backup's existence is checked in Azure storage but not deleted. xbcloud exits with an error that the backup exists

Testing the solution on GKE using manual backups:

![Screenshot 2025-03-31 at 11 14 06 PM](https://github.com/user-attachments/assets/7623ec2b-cfa2-4d45-976b-02167edd93e0)

Image used in `main` due to the Jenkins related limitation.

[K8SPXC-1475]: https://perconadev.atlassian.net/browse/K8SPXC-1475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ