### PR TITLE
K8SPXC-1475 s3 ls uses --recursive

### DIFF
--- a/percona-xtradb-cluster-5.7-backup/lib/pxc/aws.sh
+++ b/percona-xtradb-cluster-5.7-backup/lib/pxc/aws.sh
@@ -15,7 +15,7 @@ is_object_exist() {
 	local path="$2"
 
 	# '--summarize' is included to retrieve the 'Total Objects:' count for checking object/folder existence
-	res=$(aws $AWS_S3_NO_VERIFY_SSL s3 ls "s3://$bucket/$path" --summarize)
+	res=$(aws $AWS_S3_NO_VERIFY_SSL s3 ls "s3://$bucket/$path" --summarize --recursive)
 	if echo "$res" | grep -q 'Total Objects: 0'; then
 		return 0 # object/folder does not exist
 	fi

--- a/percona-xtradb-cluster-8.0-backup/lib/pxc/aws.sh
+++ b/percona-xtradb-cluster-8.0-backup/lib/pxc/aws.sh
@@ -15,7 +15,7 @@ is_object_exist() {
 	local path="$2"
 
 	# '--summarize' is included to retrieve the 'Total Objects:' count for checking object/folder existence
-	res=$(aws $AWS_S3_NO_VERIFY_SSL s3 ls "s3://$bucket/$path" --summarize)
+	res=$(aws $AWS_S3_NO_VERIFY_SSL s3 ls "s3://$bucket/$path" --summarize --recursive)
 	if echo "$res" | grep -q 'Total Objects: 0'; then
 		return 0 # object/folder does not exist
 	fi

--- a/percona-xtradb-cluster-8.4-backup/lib/pxc/aws.sh
+++ b/percona-xtradb-cluster-8.4-backup/lib/pxc/aws.sh
@@ -15,7 +15,7 @@ is_object_exist() {
 	local path="$2"
 
 	# '--summarize' is included to retrieve the 'Total Objects:' count for checking object/folder existence
-	res=$(aws $AWS_S3_NO_VERIFY_SSL s3 ls "s3://$bucket/$path" --summarize)
+	res=$(aws $AWS_S3_NO_VERIFY_SSL s3 ls "s3://$bucket/$path" --summarize --recursive)
 	if echo "$res" | grep -q 'Total Objects: 0'; then
 		return 0 # object/folder does not exist
 	fi


### PR DESCRIPTION
[![K8SPXC-1475](https://badgen.net/badge/JIRA/K8SPXC-1475/green)](https://jira.percona.com/browse/K8SPXC-1475) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

@eleo007 noticed that when we are running the following on 5.7

```
aws s3 ls s3://operator-testing/demand-backup-cloud-2025-04-08-19:22:29-full.sst_info --summarize
```

We get `Total Objects: 0`, and the tests are failing even through that the objects and the directories exist in S3. 

We add to the aforementioned command the `--recursive` option so that the path is treated as a prefix, listing everything with the same prefix and not checking only the top-level.

Note that `aws s3 ls s3://operator-testing/demand-backup-cloud-2025-04-08-19:22:29-full.sst_info/ --summarize` could work as well. 

Versions 8.0 and later work as expected, this problem is only related to 5.7.

[K8SPXC-1475]: https://perconadev.atlassian.net/browse/K8SPXC-1475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ