### PR TITLE
PSMDB. Remove unnecessary openssh update

### DIFF
--- a/percona-server-mongodb-6.0/Dockerfile
+++ b/percona-server-mongodb-6.0/Dockerfile
@@ -37,7 +37,6 @@ RUN set -ex; \
     percona-release enable psmdb-60 ${PSMDB_REPO}; \
     percona-release enable telemetry ${PSMDB_REPO}; \
     #microdnf config-manager --enable ol8_u4_security_validation; \
-    microdnf -y update openssh; \
     #miicrodnf -y update bind-export-libs; \
     #microdnf -y update glibc; \
     microdnf -y update libgcrypt; \

--- a/percona-server-mongodb-6.0/Dockerfile-dockerhub
+++ b/percona-server-mongodb-6.0/Dockerfile-dockerhub
@@ -33,7 +33,6 @@ ARG PERCONA_TELEMETRY_DISABLE=1
 RUN set -ex; \
     percona-release enable psmdb-60 ${PSMDB_REPO}; \
     #microdnf config-manager --enable ol8_u4_security_validation; \
-    microdnf -y update openssh; \
     #microdnf -y update bind-export-libs; \
     #microdnf -y update glibc; \
     microdnf -y update libgcrypt; \

--- a/percona-server-mongodb-6.0/Dockerfile.aarch64
+++ b/percona-server-mongodb-6.0/Dockerfile.aarch64
@@ -38,7 +38,6 @@ RUN set -ex; \
     percona-release enable psmdb-60 ${PSMDB_REPO}; \
     percona-release enable telemetry ${PSMDB_REPO}; \
     #microdnf config-manager --enable ol8_u4_security_validation; \
-    microdnf -y update openssh; \
     #microdnf -y update bind-export-libs; \
     #microdnf -y update glibc; \
     microdnf -y update libgcrypt; \

--- a/percona-server-mongodb-7.0/Dockerfile
+++ b/percona-server-mongodb-7.0/Dockerfile
@@ -36,7 +36,6 @@ RUN set -ex; \
     percona-release enable psmdb-70 ${PSMDB_REPO}; \
     percona-release enable telemetry ${PSMDB_REPO}; \
     #microdnf config-manager --enable ol9_u4_security_validation; \
-    microdnf -y update openssh; \
     #microdnf -y update bind-export-libs; \
     microdnf -y update glibc; \
     microdnf -y update libgcrypt; \

--- a/percona-server-mongodb-7.0/Dockerfile-dockerhub
+++ b/percona-server-mongodb-7.0/Dockerfile-dockerhub
@@ -32,7 +32,6 @@ ARG PERCONA_TELEMETRY_DISABLE=1
 RUN set -ex; \
     percona-release enable psmdb-70 ${PSMDB_REPO}; \
     #dnf config-manager --enable ol8_u4_security_validation; \
-    microdnf -y update openssh; \
     #dnf -y update bind-export-libs; \
     #dnf -y update glibc; \
     microdnf -y update libgcrypt; \

--- a/percona-server-mongodb-7.0/Dockerfile.aarch64
+++ b/percona-server-mongodb-7.0/Dockerfile.aarch64
@@ -37,7 +37,6 @@ RUN set -ex; \
     percona-release enable psmdb-70 ${PSMDB_REPO}; \
     percona-release enable telemetry ${PSMDB_REPO}; \
     #microdnf config-manager --enable ol9_u4_security_validation; \
-    microdnf -y update openssh; \
     #microdnf -y update bind-export-libs; \
     microdnf -y update glibc; \
     microdnf -y update libgcrypt; \

--- a/percona-server-mongodb-8.0/Dockerfile
+++ b/percona-server-mongodb-8.0/Dockerfile
@@ -37,7 +37,6 @@ RUN set -ex; \
     percona-release enable psmdb-80 ${PSMDB_REPO}; \
     percona-release enable telemetry ${PSMDB_REPO}; \
     #microdnf config-manager --enable ol8_u4_security_validation; \
-    microdnf -y update openssh; \
     #microdnf -y update bind-export-libs; \
     #microdnf -y update glibc; \
     microdnf -y update libgcrypt; \

--- a/percona-server-mongodb-8.0/Dockerfile-dockerhub
+++ b/percona-server-mongodb-8.0/Dockerfile-dockerhub
@@ -33,7 +33,6 @@ ARG PERCONA_TELEMETRY_DISABLE=1
 RUN set -ex; \
     percona-release enable psmdb-80 ${PSMDB_REPO}; \
     #microdnf config-manager --enable ol8_u4_security_validation; \
-    microdnf -y update openssh; \
     #microdnf -y update bind-export-libs; \
     #microdnf -y update glibc; \
     microdnf -y update libgcrypt; \

--- a/percona-server-mongodb-8.0/Dockerfile.aarch64
+++ b/percona-server-mongodb-8.0/Dockerfile.aarch64
@@ -38,7 +38,6 @@ RUN set -ex; \
     percona-release enable psmdb-80 ${PSMDB_REPO}; \
     percona-release enable telemetry ${PSMDB_REPO}; \
     #microdnf config-manager --enable ol8_u4_security_validation; \
-    microdnf -y update openssh; \
     #microdnf -y update bind-export-libs; \
     #microdnf -y update glibc; \
     microdnf -y update libgcrypt; \


### PR DESCRIPTION
Added in 42ee10fceb9aadfda77750f101049abdc841e8c to prevent [CVE-2023-38408], it's actual anymore, openssh isn't even installed by default in ubi9-minimal image