### PR TITLE
K8SPXC-1628: Allow tcmalloc as alternative in PXC images

### DIFF
--- a/percona-xtradb-cluster-8.0/Dockerfile
+++ b/percona-xtradb-cluster-8.0/Dockerfile
@@ -82,6 +82,21 @@ RUN set -ex; \
     microdnf clean all; \
     rm -rf /var/cache/dnf /var/cache/yum
 
+# tcmalloc is not available via package manager
+# Install required build tools and dependencies, build tcmalloc and cleanup
+ARG TCMALLOC_RELEASE_TAG=gperftools-2.16
+RUN microdnf install -y git gcc gcc-c++ make autoconf automake libtool which tar patch \
+    && git clone --depth 1 --branch ${TCMALLOC_RELEASE_TAG} https://github.com/gperftools/gperftools.git \
+    && cd gperftools \
+    && ./autogen.sh \
+    && ./configure --prefix=/usr --disable-debugalloc \
+    && make -j$(nproc) \
+    && make install \
+    && cd .. \
+    && rm -rf gperftools \
+    && microdnf clean all \
+    && ldconfig
+
 # create mysql user/group before mysql installation
 RUN groupadd -g 1001 mysql; \
     useradd -u 1001 -r -g 1001 -s /sbin/nologin \

--- a/percona-xtradb-cluster-8.0/Dockerfile.aarch64
+++ b/percona-xtradb-cluster-8.0/Dockerfile.aarch64
@@ -85,6 +85,21 @@ RUN set -ex; \
     microdnf clean all; \
     rm -rf /var/cache/dnf /var/cache/yum
 
+# tcmalloc is not available via package manager
+# Install required build tools and dependencies, build tcmalloc and cleanup
+ARG TCMALLOC_RELEASE_TAG=gperftools-2.16
+RUN microdnf install -y git gcc gcc-c++ make autoconf automake libtool which tar patch \
+    && git clone --depth 1 --branch ${TCMALLOC_RELEASE_TAG} https://github.com/gperftools/gperftools.git \
+    && cd gperftools \
+    && ./autogen.sh \
+    && ./configure --prefix=/usr --disable-debugalloc \
+    && make -j$(nproc) \
+    && make install \
+    && cd .. \
+    && rm -rf gperftools \
+    && microdnf clean all \
+    && ldconfig
+
 # create mysql user/group before mysql installation
 RUN groupadd -g 1001 mysql; \
     useradd -u 1001 -r -g 1001 -s /sbin/nologin \

--- a/percona-xtradb-cluster-8.4/Dockerfile
+++ b/percona-xtradb-cluster-8.4/Dockerfile
@@ -81,6 +81,21 @@ RUN set -ex; \
     microdnf clean all; \
     rm -rf /var/cache/dnf /var/cache/yum
 
+# tcmalloc is not available via package manager
+# Install required build tools and dependencies, build tcmalloc and cleanup
+ARG TCMALLOC_RELEASE_TAG=gperftools-2.16
+RUN microdnf install -y git gcc gcc-c++ make autoconf automake libtool which tar patch \
+    && git clone --depth 1 --branch ${TCMALLOC_RELEASE_TAG} https://github.com/gperftools/gperftools.git \
+    && cd gperftools \
+    && ./autogen.sh \
+    && ./configure --prefix=/usr --disable-debugalloc \
+    && make -j$(nproc) \
+    && make install \
+    && cd .. \
+    && rm -rf gperftools \
+    && microdnf clean all \
+    && ldconfig
+
 # create mysql user/group before mysql installation
 RUN groupadd -g 1001 mysql; \
     useradd -u 1001 -r -g 1001 -s /sbin/nologin \

--- a/percona-xtradb-cluster-8.4/Dockerfile.aarch64
+++ b/percona-xtradb-cluster-8.4/Dockerfile.aarch64
@@ -84,6 +84,21 @@ RUN set -ex; \
     microdnf clean all; \
     rm -rf /var/cache/dnf /var/cache/yum
 
+# tcmalloc is not available via package manager
+# Install required build tools and dependencies, build tcmalloc and cleanup
+ARG TCMALLOC_RELEASE_TAG=gperftools-2.16
+RUN microdnf install -y git gcc gcc-c++ make autoconf automake libtool which tar patch \
+    && git clone --depth 1 --branch ${TCMALLOC_RELEASE_TAG} https://github.com/gperftools/gperftools.git \
+    && cd gperftools \
+    && ./autogen.sh \
+    && ./configure --prefix=/usr --disable-debugalloc \
+    && make -j$(nproc) \
+    && make install \
+    && cd .. \
+    && rm -rf gperftools \
+    && microdnf clean all \
+    && ldconfig
+
 # create mysql user/group before mysql installation
 RUN groupadd -g 1001 mysql; \
     useradd -u 1001 -r -g 1001 -s /sbin/nologin \


### PR DESCRIPTION
[![K8SPXC-1628](https://badgen.net/badge/JIRA/K8SPXC-1628/green)](https://jira.percona.com/browse/K8SPXC-1628) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPXC-1628

Added libtcmalloc to PXC Docker images.

[K8SPXC-1628]: https://perconadev.atlassian.net/browse/K8SPXC-1628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ