### PR TITLE
K8SPS-418: remove SIGUSR1 stop signal

### DIFF
--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -47,8 +47,6 @@ RUN groupadd -g 1001 mysql
 RUN useradd -u 1001 -r -g 1001 -s /sbin/nologin \
         -c "Default Application User" mysql
 
-STOPSIGNAL SIGUSR1
-
 RUN set -ex; \
     mkdir -p /etc/haproxy/pxc /etc/haproxy-custom; \
     chown -R 1001:1001 /run /etc/haproxy /etc/haproxy/pxc /etc/haproxy-custom

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -47,8 +47,6 @@ RUN groupadd -g 1001 mysql
 RUN useradd -u 1001 -r -g 1001 -s /sbin/nologin \
         -c "Default Application User" mysql
 
-STOPSIGNAL SIGUSR1
-
 RUN set -ex; \
     mkdir -p /etc/orchestrator /var/lib/orchestrator ; \
     chown -R 1001:1001 /etc/orchestrator /var/lib/orchestrator


### PR DESCRIPTION
[![K8SPS-418](https://badgen.net/badge/JIRA/K8SPS-418/green)](https://jira.percona.com/browse/K8SPS-418) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPS-418


`haproxy` and `orchestrator` use the `SIGTERM` signal for graceful termination

[K8SPS-418]: https://perconadev.atlassian.net/browse/K8SPS-418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ