### PR TITLE
K8SPG-613: add procps-ng (pkill) in official pgbackrest and pgboucer

### DIFF
--- a/percona-pgbackrest/Dockerfile
+++ b/percona-pgbackrest/Dockerfile
@@ -43,6 +43,7 @@ RUN set -ex; \
     microdnf -y install \
         --enablerepo="ol9_developer_EPEL" \
         percona-pgbackrest \
+        procps-ng \
         nss_wrapper; \
     microdnf clean all; \
     rm -rf /var/cache/dnf /var/cache/yum

--- a/percona-pgbouncer/Dockerfile
+++ b/percona-pgbouncer/Dockerfile
@@ -39,6 +39,7 @@ RUN groupadd -g 1001 pgbouncer; \
 RUN set -ex; \
     microdnf -y update; \
     microdnf -y install \
+        procps-ng \
         percona-pgbouncer; \
     microdnf clean all; \
     rm -rf /var/cache/dnf /var/cache/yum


### PR DESCRIPTION
[![K8SPG-613](https://badgen.net/badge/JIRA/K8SPG-613/green)](https://jira.percona.com/browse/K8SPG-613) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Operator requires `pkill` in pgbackrest and pgboucer images.