### PR TITLE
PSMDB-1730 The package cyrus-sasl-plain is not bundled in docker imag…

### DIFF
--- a/percona-server-mongodb-6.0/Dockerfile
+++ b/percona-server-mongodb-6.0/Dockerfile
@@ -51,6 +51,7 @@ RUN set -ex; \
         tar \
         oniguruma \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     curl -Lf -o /tmp/Percona-Server-MongoDB-server.rpm http://repo.percona.com/psmdb-60/yum/${PSMDB_REPO}/9/RPMS/x86_64/percona-server-mongodb-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \

--- a/percona-server-mongodb-6.0/Dockerfile-dockerhub
+++ b/percona-server-mongodb-6.0/Dockerfile-dockerhub
@@ -47,6 +47,7 @@ RUN set -ex; \
         tar \
         oniguruma \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     curl -Lf -o /tmp/Percona-Server-MongoDB-server.rpm http://repo.percona.com/psmdb-60/yum/${PSMDB_REPO}/9/RPMS/x86_64/percona-server-mongodb-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \

--- a/percona-server-mongodb-6.0/Dockerfile.aarch64
+++ b/percona-server-mongodb-6.0/Dockerfile.aarch64
@@ -52,6 +52,7 @@ RUN set -ex; \
         tar \
         oniguruma \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     ARCH="$(uname -m)"; \

--- a/percona-server-mongodb-6.0/Dockerfile.debug
+++ b/percona-server-mongodb-6.0/Dockerfile.debug
@@ -34,6 +34,7 @@ RUN set -ex; \
         nc \
         telnet \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         numactl \
         percona-server-mongodb-server-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-debuginfo-${FULL_PERCONA_VERSION} \

--- a/percona-server-mongodb-6.0/Dockerfile.k8s
+++ b/percona-server-mongodb-6.0/Dockerfile.k8s
@@ -59,6 +59,7 @@ RUN set -ex; \
         oniguruma \
         procps-ng \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     curl -Lf -o /tmp/Percona-Server-MongoDB-server.rpm http://repo.percona.com/psmdb-60/yum/${PSMDB_REPO}/9/RPMS/x86_64/percona-server-mongodb-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \

--- a/percona-server-mongodb-6.0/Dockerfile.ubi8
+++ b/percona-server-mongodb-6.0/Dockerfile.ubi8
@@ -45,6 +45,7 @@ RUN set -ex; \
         procps-ng \
         tar \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     curl -Lf -o /tmp/Percona-Server-MongoDB-server.rpm http://repo.percona.com/psmdb-60/yum/${PSMDB_REPO}/8/RPMS/x86_64/percona-server-mongodb-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \

--- a/percona-server-mongodb-6.0/Dockerfile.ubi9
+++ b/percona-server-mongodb-6.0/Dockerfile.ubi9
@@ -42,6 +42,7 @@ RUN set -ex; \
         procps-ng \
         tar \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     curl -Lf -o /tmp/Percona-Server-MongoDB-server.rpm http://repo.percona.com/psmdb-60/yum/${PSMDB_REPO}/9/RPMS/x86_64/percona-server-mongodb-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \

--- a/percona-server-mongodb-7.0/Dockerfile
+++ b/percona-server-mongodb-7.0/Dockerfile
@@ -50,6 +50,7 @@ RUN set -ex; \
         tar \
         oniguruma \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     curl -Lf -o /tmp/Percona-Server-MongoDB-server.rpm http://repo.percona.com/psmdb-70/yum/${PSMDB_REPO}/9/RPMS/x86_64/percona-server-mongodb-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \

--- a/percona-server-mongodb-7.0/Dockerfile-dockerhub
+++ b/percona-server-mongodb-7.0/Dockerfile-dockerhub
@@ -46,6 +46,7 @@ RUN set -ex; \
         tar \
         oniguruma \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     curl -Lf -o /tmp/Percona-Server-MongoDB-server.rpm http://repo.percona.com/psmdb-70/yum/${PSMDB_REPO}/9/RPMS/x86_64/percona-server-mongodb-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \

--- a/percona-server-mongodb-7.0/Dockerfile.aarch64
+++ b/percona-server-mongodb-7.0/Dockerfile.aarch64
@@ -51,6 +51,7 @@ RUN set -ex; \
         tar \
         oniguruma \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     ARCH="$(uname -m)"; \

--- a/percona-server-mongodb-7.0/Dockerfile.debug
+++ b/percona-server-mongodb-7.0/Dockerfile.debug
@@ -34,6 +34,7 @@ RUN set -ex; \
         nc \
         telnet \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         numactl \
         percona-server-mongodb-server-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-debuginfo-${FULL_PERCONA_VERSION} \

--- a/percona-server-mongodb-7.0/Dockerfile.k8s
+++ b/percona-server-mongodb-7.0/Dockerfile.k8s
@@ -64,6 +64,7 @@ RUN set -ex; \
         tar \
         procps-ng \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     curl -Lf -o /tmp/Percona-Server-MongoDB-server.rpm http://repo.percona.com/psmdb-70/yum/${PSMDB_REPO}/9/RPMS/x86_64/percona-server-mongodb-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \

--- a/percona-server-mongodb-7.0/Dockerfile.ubi8
+++ b/percona-server-mongodb-7.0/Dockerfile.ubi8
@@ -45,6 +45,7 @@ RUN set -ex; \
         procps-ng \
         tar \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     curl -Lf -o /tmp/Percona-Server-MongoDB-server.rpm http://repo.percona.com/psmdb-70/yum/${PSMDB_REPO}/8/RPMS/x86_64/percona-server-mongodb-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \

--- a/percona-server-mongodb-7.0/Dockerfile.ubi9
+++ b/percona-server-mongodb-7.0/Dockerfile.ubi9
@@ -42,6 +42,7 @@ RUN set -ex; \
         procps-ng \
         tar \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     curl -Lf -o /tmp/Percona-Server-MongoDB-server.rpm http://repo.percona.com/psmdb-70/yum/${PSMDB_REPO}/9/RPMS/x86_64/percona-server-mongodb-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \

--- a/percona-server-mongodb-8.0/Dockerfile
+++ b/percona-server-mongodb-8.0/Dockerfile
@@ -51,6 +51,7 @@ RUN set -ex; \
         tar \
         oniguruma \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     curl -Lf -o /tmp/Percona-Server-MongoDB-server.rpm http://repo.percona.com/psmdb-80/yum/${PSMDB_REPO}/9/RPMS/x86_64/percona-server-mongodb-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \

--- a/percona-server-mongodb-8.0/Dockerfile-dockerhub
+++ b/percona-server-mongodb-8.0/Dockerfile-dockerhub
@@ -47,6 +47,7 @@ RUN set -ex; \
         tar \
         oniguruma \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     curl -Lf -o /tmp/Percona-Server-MongoDB-server.rpm http://repo.percona.com/psmdb-80/yum/${PSMDB_REPO}/9/RPMS/x86_64/percona-server-mongodb-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \

--- a/percona-server-mongodb-8.0/Dockerfile.aarch64
+++ b/percona-server-mongodb-8.0/Dockerfile.aarch64
@@ -52,6 +52,7 @@ RUN set -ex; \
         tar \
         oniguruma \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
 	echo test

--- a/percona-server-mongodb-8.0/Dockerfile.debug
+++ b/percona-server-mongodb-8.0/Dockerfile.debug
@@ -34,6 +34,7 @@ RUN set -ex; \
         nc \
         telnet \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         numactl \
         percona-server-mongodb-server-debuginfo-${FULL_PERCONA_VERSION} \
         percona-server-mongodb-tools-debuginfo-${FULL_PERCONA_VERSION} \

--- a/percona-server-mongodb-8.0/Dockerfile.k8s
+++ b/percona-server-mongodb-8.0/Dockerfile.k8s
@@ -65,6 +65,7 @@ RUN set -ex; \
         tar \
         procps-ng \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     curl -Lf -o /tmp/Percona-Server-MongoDB-server.rpm http://repo.percona.com/psmdb-80/yum/${PSMDB_REPO}/9/RPMS/x86_64/percona-server-mongodb-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \

--- a/percona-server-mongodb-8.0/Dockerfile.ubi8
+++ b/percona-server-mongodb-8.0/Dockerfile.ubi8
@@ -46,6 +46,7 @@ RUN set -ex; \
         procps-ng \
         tar \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     curl -Lf -o /tmp/Percona-Server-MongoDB-server.rpm http://repo.percona.com/psmdb-80/yum/${PSMDB_REPO}/8/RPMS/x86_64/percona-server-mongodb-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \

--- a/percona-server-mongodb-8.0/Dockerfile.ubi9
+++ b/percona-server-mongodb-8.0/Dockerfile.ubi9
@@ -47,6 +47,7 @@ RUN set -ex; \
         procps-ng \
         tar \
         cyrus-sasl-gssapi \
+        cyrus-sasl-plain \
         policycoreutils; \
         \
     curl -Lf -o /tmp/Percona-Server-MongoDB-server.rpm http://repo.percona.com/psmdb-80/yum/${PSMDB_REPO}/9/RPMS/x86_64/percona-server-mongodb-server-${FULL_PERCONA_VERSION}.x86_64.rpm; \


### PR DESCRIPTION
[![PSMDB-1730](https://badgen.net/badge/JIRA/PSMDB-1730/green)](https://jira.percona.com/browse/PSMDB-1730) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…es for PSMDB 6, 7 and 8 so plain SASL authentication fails on these versions

[PSMDB-1730]: https://perconadev.atlassian.net/browse/PSMDB-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ