### PR TITLE
fix: is_object_exist false positive when S3-compatible storage returns NoSuchKey on stderr

### DIFF
--- a/percona-xtradb-cluster-5.7-backup/lib/pxc/aws.sh
+++ b/percona-xtradb-cluster-5.7-backup/lib/pxc/aws.sh
@@ -15,7 +15,10 @@ is_object_exist() {
 	local path="$2"
 
 	# '--summarize' is included to retrieve the 'Total Objects:' count for checking object/folder existence
-	res=$(aws $AWS_S3_NO_VERIFY_SSL s3 ls "s3://$bucket/$path" --summarize --recursive)
+	res=$(aws $AWS_S3_NO_VERIFY_SSL s3 ls "s3://$bucket/$path" --summarize --recursive 2>&1)
+	if echo "$res" | grep -q '(NoSuchKey)'; then
+		return 0
+	fi
 	if echo "$res" | grep -q 'Total Objects: 0'; then
 		return 0 # object/folder does not exist
 	fi

--- a/percona-xtradb-cluster-8.0-backup/lib/pxc/aws.sh
+++ b/percona-xtradb-cluster-8.0-backup/lib/pxc/aws.sh
@@ -15,7 +15,10 @@ is_object_exist() {
 	local path="$2"
 
 	# '--summarize' is included to retrieve the 'Total Objects:' count for checking object/folder existence
-	res=$(aws $AWS_S3_NO_VERIFY_SSL s3 ls "s3://$bucket/$path" --summarize --recursive)
+	res=$(aws $AWS_S3_NO_VERIFY_SSL s3 ls "s3://$bucket/$path" --summarize  --recursive 2>&1)
+	if echo "$res" | grep -q '(NoSuchKey)'; then
+		return 1
+	fi
 	if echo "$res" | grep -q 'Total Objects: 0'; then
 		return 1 # object/folder does not exist
 	fi

--- a/percona-xtradb-cluster-8.4-backup/lib/pxc/aws.sh
+++ b/percona-xtradb-cluster-8.4-backup/lib/pxc/aws.sh
@@ -15,7 +15,10 @@ is_object_exist() {
 	local path="$2"
 
 	# '--summarize' is included to retrieve the 'Total Objects:' count for checking object/folder existence
-	res=$(aws $AWS_S3_NO_VERIFY_SSL s3 ls "s3://$bucket/$path" --summarize --recursive)
+	res=$(aws $AWS_S3_NO_VERIFY_SSL s3 ls "s3://$bucket/$path" --summarize --recursive 2>&1)
+	if echo "$res" | grep -q '(NoSuchKey)'; then
+		return 1
+	fi
 	if echo "$res" | grep -q 'Total Objects: 0'; then
 		return 1 # object/folder does not exist
 	fi


### PR DESCRIPTION
Due to the high volume of requests, we're unable to provide free service for this account. To continue using the service, please **[upgarde to a paid plan](https://pullrequestbadge.com/unlock/1683025?utm_medium=github&utm_source=percona&utm_campaign=unlock_text)**.

<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

## Problem
 
When using S3-compatible storage such as Alibaba Cloud OSS as a backup target,
`is_object_exist()` incorrectly returns exists for a non-existent object, causing
the backup flow to stall.
 
The function currently captures only stdout and checks for `Total Objects: 0` to
determine non-existence. On some S3-compatible implementations, the AWS CLI writes
a `NoSuchKey` error to stderr instead of producing the expected summarize output.
Since stderr was discarded, `$res` ends up empty, the check never matches, and the
function falls through to return exists.
 
## Fix
 
Redirect stderr to stdout (`2>&1`) so all AWS CLI output is available in `$res`,
then treat a `NoSuchKey` response as object-not-found explicitly, before the
existing `Total Objects: 0` check.
 
This change is applied consistently across the 5.7, 8.0 and 8.4 backup images.
 
## Testing
 
Verified on Alibaba Cloud OSS (internal endpoint) with Percona XtraDB Cluster
Operator. Before the fix the backup pod exited with an error; after the fix the
backup completes successfully. 