### PR TITLE
K8SPXC-1821 | update cron dependency for logrotate

### DIFF
--- a/fluentbit/Dockerfile
+++ b/fluentbit/Dockerfile
@@ -64,18 +64,33 @@ RUN set -ex; \
     tar xvf /tmp/go-cron.tar.gz -C /usr/bin; \
     rm -rf /var/cache /tmp/go-cron.tar.gz
 
+
 # Install supercronic for cron
 ARG SUPERCRONIC_VERSION=v0.2.44
 RUN set -ex; \
+    cd /tmp; \
     arch=$(uname -m); \
     case "$arch" in \
-        x86_64)  sc_arch=amd64 ;; \
-        aarch64) sc_arch=arm64 ;; \
-        *)       echo "unsupported architecture: $arch" && exit 1 ;; \
+        x86_64) \
+            SUPERCRONIC=supercronic-linux-amd64; \
+            SUPERCRONIC_SHA1SUM=6eb0a8e1e6673675dc67668c1a9b6409f79c37bc ;; \
+        i386|i686) \
+            SUPERCRONIC=supercronic-linux-386; \
+            SUPERCRONIC_SHA1SUM=58c094ebdff4c29286a3bb6152d64a5070d9682a ;; \
+        armv7l|armv6l|armhf) \
+            SUPERCRONIC=supercronic-linux-arm; \
+            SUPERCRONIC_SHA1SUM=4f69f55febc78fbb10f1c0c85b907682b4da9300 ;; \
+        aarch64) \
+            SUPERCRONIC=supercronic-linux-arm64; \
+            SUPERCRONIC_SHA1SUM=6c6cba4cde1dd4a1dd1e7fb23498cde1b57c226c ;; \
+        *) \
+            echo "unsupported architecture: $arch" && exit 1 ;; \
     esac; \
-    curl -fsSLo /usr/bin/supercronic \
-        "https://github.com/aptible/supercronic/releases/download/${SUPERCRONIC_VERSION}/supercronic-linux-${sc_arch}"; \
-    chmod +x /usr/bin/supercronic
+    curl -fsSLO "https://github.com/aptible/supercronic/releases/download/${SUPERCRONIC_VERSION}/${SUPERCRONIC}"; \
+    echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c -; \
+    chmod +x "${SUPERCRONIC}"; \
+    mv "${SUPERCRONIC}" "/usr/local/bin/${SUPERCRONIC}"; \
+    ln -sf "/usr/local/bin/${SUPERCRONIC}" /usr/bin/supercronic
 
 RUN groupadd -g 1001 mysql
 RUN useradd -u 1001 -r -g 1001 -s /sbin/nologin \

--- a/fluentbit/Dockerfile
+++ b/fluentbit/Dockerfile
@@ -64,6 +64,19 @@ RUN set -ex; \
     tar xvf /tmp/go-cron.tar.gz -C /usr/bin; \
     rm -rf /var/cache /tmp/go-cron.tar.gz
 
+# Install supercronic for cron
+ARG SUPERCRONIC_VERSION=v0.2.44
+RUN set -ex; \
+    arch=$(uname -m); \
+    case "$arch" in \
+        x86_64)  sc_arch=amd64 ;; \
+        aarch64) sc_arch=arm64 ;; \
+        *)       echo "unsupported architecture: $arch" && exit 1 ;; \
+    esac; \
+    curl -fsSLo /usr/bin/supercronic \
+        "https://github.com/aptible/supercronic/releases/download/${SUPERCRONIC_VERSION}/supercronic-linux-${sc_arch}"; \
+    chmod +x /usr/bin/supercronic
+
 RUN groupadd -g 1001 mysql
 RUN useradd -u 1001 -r -g 1001 -s /sbin/nologin \
         -c "Default Application User" mysql

--- a/fluentbit/dockerdir/entrypoint.sh
+++ b/fluentbit/dockerdir/entrypoint.sh
@@ -11,7 +11,7 @@ if [  "$1" = 'logrotate' ]; then
         cat /tmp/passwd > /etc/passwd
         rm -rf /tmp/passwd
     fi
-    exec go-cron "0 0 * * *" sh -c "logrotate -s /opt/percona/logrotate/logrotate.status /opt/percona/logrotate/logrotate-$SERVICE_TYPE.conf;/usr/bin/find /var/lib/mysql/ -name GRA_*.log -mtime +7 -delete"
+    exec_cron
 else
     if [ "$1" = 'fluent-bit' ]; then
         fluentbit_opt+='-c /etc/fluentbit/fluentbit.conf'
@@ -21,3 +21,13 @@ else
     exec "$@" $fluentbit_opt
 fi
 
+
+exec_cron() {
+    logrotate_cron_cmd="logrotate -s /opt/percona/logrotate/logrotate.status /opt/percona/logrotate/logrotate-${SERVICE_TYPE}.conf;/usr/bin/find /var/lib/mysql/ -name 'GRA_*.log' -mtime +7 -delete"
+    if [ -f /usr/bin/supercronic ]; then
+        printf '0 0 * * * %s\n' "$logrotate_cron_cmd" > /tmp/crontab
+        exec supercronic /tmp/crontab
+    else
+        exec go-cron "0 0 * * *" sh -c "$logrotate_cron_cmd"
+    fi
+}

--- a/fluentbit/dockerdir/entrypoint.sh
+++ b/fluentbit/dockerdir/entrypoint.sh
@@ -4,6 +4,16 @@ set -o xtrace
 
 export PATH=$PATH:/opt/fluent-bit/bin
 
+exec_cron() {
+    logrotate_cron_cmd="logrotate -s /opt/percona/logrotate/logrotate.status /opt/percona/logrotate/logrotate-${SERVICE_TYPE}.conf;/usr/bin/find /var/lib/mysql/ -name 'GRA_*.log' -mtime +7 -delete"
+    if [ -f /usr/bin/supercronic ]; then
+        printf '0 0 * * * %s\n' "$logrotate_cron_cmd" > /tmp/crontab
+        exec supercronic /tmp/crontab
+    else
+        exec go-cron "0 0 * * *" sh -c "$logrotate_cron_cmd"
+    fi
+}
+
 if [  "$1" = 'logrotate' ]; then
     if [[ $EUID != 1001 ]]; then
         # logrotate requires UID in /etc/passwd
@@ -22,12 +32,3 @@ else
 fi
 
 
-exec_cron() {
-    logrotate_cron_cmd="logrotate -s /opt/percona/logrotate/logrotate.status /opt/percona/logrotate/logrotate-${SERVICE_TYPE}.conf;/usr/bin/find /var/lib/mysql/ -name 'GRA_*.log' -mtime +7 -delete"
-    if [ -f /usr/bin/supercronic ]; then
-        printf '0 0 * * * %s\n' "$logrotate_cron_cmd" > /tmp/crontab
-        exec supercronic /tmp/crontab
-    else
-        exec go-cron "0 0 * * *" sh -c "$logrotate_cron_cmd"
-    fi
-}


### PR DESCRIPTION
Due to the high volume of requests, we're unable to provide free service for this account. To continue using the service, please **[upgarde to a paid plan](https://pullrequestbadge.com/unlock/1683025?utm_medium=github&utm_source=percona&utm_campaign=unlock_text)**.

<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Related to - https://perconadev.atlassian.net/browse/K8SPXC-1821

Adds `supercronic` for running cron in logrotate container.

- The current `go-cron` dependency does not have an ARM build, which means logrotate cannot work on ARM nodes
- While it is possible to configure the image to build `go-cron` from source, it is worth noting that the project has not been active for ~12 years which means it is a good idea to look for a more actively maintained dependency
- We add `supercronic` as a cron executor. Currently we will also keep `go-cron` for backwards compatiblity. The logrotate script shall use whichever is available 