### PR TITLE
K8SPSMDB-1601 fluentbit

### DIFF
--- a/fluentbit/Dockerfile
+++ b/fluentbit/Dockerfile
@@ -15,7 +15,7 @@ ENV PERCONA_SERVER_BUILD_VERSION=1
 ENV PERCONA_VERSION=${PERCONA_SERVER_VERSION}-${PERCONA_SERVER_PERC_VERSION}.${PERCONA_SERVER_BUILD_VERSION}.el9
 
 # install exact version of Fluent Bit for repeatability
-ENV FLUENTBIT_VERSION=5.0.6-1
+ENV FLUENTBIT_VERSION=5.0.9-1
 
 RUN export GNUPGHOME="$(mktemp -d)" \
     && gpg --keyserver https://packages.fluentbit.io/fluentbit.key --recv-keys C3C0A28534B9293EAF51FABD9F9DDC083888C1CD \

--- a/fluentbit/Dockerfile
+++ b/fluentbit/Dockerfile
@@ -70,23 +70,23 @@ RUN set -ex; \
 
 
 # Install supercronic for cron
-ARG SUPERCRONIC_VERSION=v0.2.46
+ARG SUPERCRONIC_VERSION=v0.2.47
 RUN set -ex; \
     cd /tmp; \
     arch=$(uname -m); \
     case "$arch" in \
         x86_64) \
             SUPERCRONIC=supercronic-linux-amd64; \
-            SUPERCRONIC_SHA1SUM=5bcefed628e32adc08e32634db2d10e9230dbca0 ;; \
+            SUPERCRONIC_SHA1SUM=712d2ece75da6f6e530192a151488578153e4e96 ;; \
         i386|i686) \
             SUPERCRONIC=supercronic-linux-386; \
-            SUPERCRONIC_SHA1SUM=7630904df9a240b6e0f8171cac46ec799fbe1ad9 ;; \
+            SUPERCRONIC_SHA1SUM=c3c8bd5d200c2b55cf2f9590542139f205194fb7 ;; \
         armv7l|armv6l|armhf) \
             SUPERCRONIC=supercronic-linux-arm; \
-            SUPERCRONIC_SHA1SUM=04be50a960eafa325185d037c9b4ad6cd88a0e0b ;; \
+            SUPERCRONIC_SHA1SUM=dcc8535b46bd9752fbbe177fddd7f6f0451da9a4 ;; \
         aarch64) \
             SUPERCRONIC=supercronic-linux-arm64; \
-            SUPERCRONIC_SHA1SUM=639ab81a72771990790df7ee87d9acfe88e5fa83 ;; \
+            SUPERCRONIC_SHA1SUM=93323899ddca3f1198f1796a4bf4418ed1e7982e ;; \
         *) \
             echo "unsupported architecture: $arch" && exit 1 ;; \
     esac; \


### PR DESCRIPTION
Due to the high volume of requests, we're unable to provide free service for this account. To continue using the service, please **[upgarde to a paid plan](https://pullrequestbadge.com/unlock/1683025?utm_medium=github&utm_source=percona&utm_campaign=unlock_text)**.

<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

#### High Severity Vulnerabilities

| Package | Version | CVE |
|---------|---------|-----|
| expat | 2.5.0-6.el9 | [CVE-2026-45186](https://cloud.cd.percona.com/view/MISC/job/operators-vuln-scan/13/testReport/junit/percona-fluentbit-5.0.6-1%20__%20expat-2.5.0-6/el9/_HIGH__CVE_2026_45186/) |
| openssl | 3.5.5-3.el9_8 | [CVE-2026-45447](https://cloud.cd.percona.com/view/MISC/job/operators-vuln-scan/13/testReport/junit/percona-fluentbit-5.0.6-1%20__%20openssl-1_3.5.5-3/el9_8/_HIGH__CVE_2026_45447/) |
| openssl-libs | 3.5.5-3.el9_8 | [CVE-2026-45447](https://cloud.cd.percona.com/view/MISC/job/operators-vuln-scan/13/testReport/junit/percona-fluentbit-5.0.6-1%20__%20openssl-libs-1_3.5.5-3/el9_8/_HIGH__CVE_2026_45447/) |
| Go stdlib | v1.26.3 | [CVE-2026-27145](https://cloud.cd.percona.com/view/MISC/job/operators-vuln-scan/13/testReport/junit/percona-fluentbit-5.0.6-1%20__%20stdlib-v1.26/3/_HIGH__CVE_2026_27145/) |
| Go stdlib | v1.26.3 | [CVE-2026-42504](https://cloud.cd.percona.com/view/MISC/job/operators-vuln-scan/13/testReport/junit/percona-fluentbit-5.0.6-1%20__%20stdlib-v1.26/3/_HIGH__CVE_2026_42504/) |

#### Missing to fix

| Package | Current Version | Severity | CVE | Recommended Fix |
|---------|-----------------|----------|-----|-----------------|
| Go stdlib | v1.26.4 | HIGH | CVE-2026-39822 | Rebuild the binary with Go **1.26.5** or later. :contentReference[oaicite:0]{index=0} 