### PR TITLE
K8SPG-1051 fix upgrade images

### DIFF
--- a/postgresql-containers/community/build/upgrade-ubi8/Dockerfile
+++ b/postgresql-containers/community/build/upgrade-ubi8/Dockerfile
@@ -98,10 +98,6 @@ RUN for pg_version in 17 16 15 14; do \
         microdnf -y install --nodocs $pkgs; \
     done && microdnf -y clean all && rm -rf /var/cache/dnf /var/cache/yum
 
-# Remove unused perl modules pulled in by the perl metapackage
-RUN set -ex; \
-    rpm -e --nodeps perl-Archive-Tar perl-IO-Compress
-
 RUN [ "$(arch)" != "x86_64" ] && exit 0; \
     EL_VER=$(. /etc/os-release && echo "${VERSION_ID%%.*}"); \
     [ "${PG_MAJOR}" -ge 18 ] && [ "${EL_VER}" -lt 9 ] && exit 0; \

--- a/postgresql-containers/community/build/upgrade/Dockerfile
+++ b/postgresql-containers/community/build/upgrade/Dockerfile
@@ -94,10 +94,6 @@ RUN for pg_version in 17 16 15 14; do \
         microdnf -y install --nodocs $pkgs; \
     done && microdnf -y clean all && rm -rf /var/cache/dnf /var/cache/yum
 
-# Remove unused perl modules pulled in by the perl metapackage
-RUN set -ex; \
-    rpm -e --nodeps perl-Archive-Tar perl-IO-Compress
-
 RUN [ "$(arch)" != "x86_64" ] && exit 0; \
     EL_VER=$(. /etc/os-release && echo "${VERSION_ID%%.*}"); \
     [ "${PG_MAJOR}" -ge 18 ] && [ "${EL_VER}" -lt 9 ] && exit 0; \

--- a/postgresql-containers/community/transform.py
+++ b/postgresql-containers/community/transform.py
@@ -92,6 +92,16 @@ UPGRADE_EXTRACT_MARKER = re.compile(r'tar\s+-xvzf\s+downloaded-packages\.tar\.gz
 # gpsbabel download block (PostGIS dep from Oracle Linux EPEL; not needed without PostGIS)
 GPSBABEL_MARKER = re.compile(r'gpsbabel')
 
+# Perl metapackage cleanup — only valid when the transformed image still installs
+# perl. In the upgrade images the install block that pulls perl in is Oracle-specific
+# and gets dropped wholesale, so the cleanup must be dropped with it.
+PERL_CLEANUP_BLOCK = re.compile(
+    r'\n?# Remove unused perl modules pulled in by the perl metapackage\n'
+    r'RUN set -ex; \\\n'
+    r'\s*rpm -e --nodeps perl-Archive-Tar perl-IO-Compress\n'
+)
+PERL_PACKAGE_LINE = re.compile(r'^\s*perl \\$', re.M)
+
 # Multi-PG-version loop in upgrade image — replaced wholesale with PGDG equivalent
 UPGRADE_LOOP_MARKER = re.compile(r'for\s+pg_version\s+in\s+\d+.*\bdo\b')
 
@@ -387,6 +397,10 @@ def transform(source_path: Path) -> str:
             i += 1
 
     result = '\n'.join(output)
+
+    # Drop the perl cleanup when nothing in the transformed image installs perl
+    if not PERL_PACKAGE_LINE.search(result):
+        result = PERL_CLEANUP_BLOCK.sub('', result)
 
     # Apply pgaudit legacy name fixup for PG ≤ 15
     if pg_version and pg_version in PGAUDIT_LEGACY:


### PR DESCRIPTION
Due to the high volume of requests, we're unable to provide free service for this account. To continue using the service, please **[upgarde to a paid plan](https://pullrequestbadge.com/unlock/1683025?utm_medium=github&utm_source=percona&utm_campaign=unlock_text)**.

<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

The perl metapackage is installed by an Oracle-specific block that transform.py removes, so perl-Archive-Tar/perl-IO-Compress are never present in the community upgrade images and rpm -e fails the build. 
transform.py now drops the cleanup step when the transformed image does not install perl. 

https://cloud.cd.percona.com/view/PG/job/pg-community-docker-build/